### PR TITLE
Fixes the state bugs by in widget

### DIFF
--- a/components/main/layout/WidgetPane/WidgetPane.tsx
+++ b/components/main/layout/WidgetPane/WidgetPane.tsx
@@ -3,6 +3,13 @@ import React, { useContext, useEffect, useState } from "react";
 import { WidgetContext } from "../layout";
 import styles from "./WidgetPane.module.scss";
 
+const Widget = dynamic<{}>(
+  () => import("../../widget/components/Widget").then((mod) => mod.Widget),
+  {
+    ssr: false,
+  },
+);
+
 export const WidgetPane: React.FC = () => {
   const followThreshold = 20;
   const closeThreshold = 140;
@@ -10,12 +17,6 @@ export const WidgetPane: React.FC = () => {
   const [currentY, setCurrentY] = useState(0);
   const [dragging, setDragging] = useState(false);
   const [widgetOpen, setWidgetOpen] = useContext(WidgetContext);
-  const Widget = dynamic<{}>(
-    () => import("../../widget/components/Widget").then((mod) => mod.Widget),
-    {
-      ssr: false,
-    },
-  );
 
   // On initial load, have no animation
   // Then reset on render


### PR DESCRIPTION
Turns out you were right @philiphand !

The dynamic import should be outside the react render function. What happened here, was that the widget was re-imported whenever you closed and opened the panel, which lead to some state trouble with which step you were on, as well as completely unnecessary calls to `/organizations/active` and `/referrals/types`.

Moving the import outside the render function fixes the issue.

Closes #321 (satisfying issue number btw 🎸 )