### PR TITLE
Updates referral logic

### DIFF
--- a/components/shared/components/Widget/store/referrals/actions.ts
+++ b/components/shared/components/Widget/store/referrals/actions.ts
@@ -1,16 +1,31 @@
 import actionCreatorFactory from "typescript-fsa";
 import { ReferralData, ReferralType } from "../../types/Temp";
+import { ReferralActionTypes, SELECT_REFERRAL, SET_OTHER_TEXT } from "./types";
 
 const actionCreator = actionCreatorFactory();
 
-export const fetchReferralsAction = actionCreator.async<
-  undefined,
-  [ReferralType],
-  Error
->("FETCH_REFERRALS");
+export const fetchReferralsAction = actionCreator.async<undefined, [ReferralType], Error>(
+  "FETCH_REFERRALS",
+);
 
-export const submitReferralAction = actionCreator.async<
-  ReferralData,
-  boolean,
-  Error
->("SUBMIT_REFERRAL");
+export const submitReferralAction = actionCreator.async<ReferralData, boolean, Error>(
+  "SUBMIT_REFERRAL",
+);
+
+export function selectReferralAction(ref: ReferralData): ReferralActionTypes {
+  return {
+    type: SELECT_REFERRAL,
+    payload: {
+      ref,
+    },
+  };
+}
+
+export function setOtherText(text: string): ReferralActionTypes {
+  return {
+    type: SET_OTHER_TEXT,
+    payload: {
+      text,
+    },
+  };
+}

--- a/components/shared/components/Widget/store/referrals/reducer.ts
+++ b/components/shared/components/Widget/store/referrals/reducer.ts
@@ -2,10 +2,12 @@ import { Reducer } from "redux";
 import { isType } from "typescript-fsa";
 import { Referrals } from "../state";
 import { fetchReferralsAction } from "./actions";
-import { ReferralActionTypes } from "./types";
+import { ReferralActionTypes, SELECT_REFERRAL, SET_OTHER_TEXT } from "./types";
 
 const initialState: Referrals = {
-  websiteSession: new Date().getTime().toString()
+  websiteSession: new Date().getTime().toString(),
+  selectedReferrals: [],
+  otherText: "",
 };
 
 /**
@@ -18,12 +20,35 @@ const initialState: Referrals = {
 
 export const referralReducer: Reducer<Referrals, ReferralActionTypes> = (
   state: Referrals = initialState,
-  action: ReferralActionTypes
+  action: ReferralActionTypes,
 ) => {
   if (isType(action, fetchReferralsAction.done)) {
     return {
       ...state,
       referrals: action.payload.result,
+    };
+  }
+
+  if (action.type === SELECT_REFERRAL) {
+    if (action.payload.ref.active) {
+      return {
+        ...state,
+        selectedReferrals: [...state.selectedReferrals, action.payload.ref.referralID],
+      };
+    } else {
+      return {
+        ...state,
+        selectedReferrals: state.selectedReferrals.filter(
+          (referralID) => referralID !== action.payload.ref.referralID,
+        ),
+      };
+    }
+  }
+
+  if (action.type === SET_OTHER_TEXT) {
+    return {
+      ...state,
+      otherText: action.payload.text,
     };
   }
 

--- a/components/shared/components/Widget/store/referrals/types.ts
+++ b/components/shared/components/Widget/store/referrals/types.ts
@@ -1,3 +1,21 @@
 import { AnyAction } from "redux";
+import { ReferralData } from "../../types/Temp";
 
-export type ReferralActionTypes = AnyAction;
+export const SELECT_REFERRAL = "SELECT_REFERRAL";
+export const SET_OTHER_TEXT = "SET_OTHER_TEXT";
+
+interface SelectReferral {
+  type: typeof SELECT_REFERRAL;
+  payload: {
+    ref: ReferralData;
+  };
+}
+
+interface SetOtherText {
+  type: typeof SET_OTHER_TEXT;
+  payload: {
+    text: string;
+  };
+}
+
+export type ReferralActionTypes = SelectReferral | SetOtherText;

--- a/components/shared/components/Widget/store/state.ts
+++ b/components/shared/components/Widget/store/state.ts
@@ -63,6 +63,8 @@ export interface Donor extends DonorInput {
 
 export interface Referrals {
   referrals?: [ReferralType];
+  selectedReferrals: number[];
+  otherText: string;
   websiteSession: string;
 }
 

--- a/components/shared/components/Widget/types/Temp.ts
+++ b/components/shared/components/Widget/types/Temp.ts
@@ -19,6 +19,7 @@ export interface OrganizationShare {
 
 export interface ReferralData {
   referralID: number;
+  active: boolean;
   donorID?: number;
   comment?: string;
 }


### PR DESCRIPTION
Changes referrals to new behaviour:

* You can now select one or more options in the widget, and they will be highlighted
* Referral responses are stored in global state, and thus persistent across pane navigation
* Website session is sent to the backend alongside with donorid and referralid, such that we may differentiate between different anonymous donors