### PR TITLE
Limit formatting to file extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "test": "jest",
-    "format": "prettier --write .",
+    "format": "prettier --write ./**/*.{js,ts,jsx,tsx,json,md,css,scss,yml}",
     "prepare": "husky install"
   },
   "dependencies": {
@@ -101,6 +101,6 @@
     "webpack": "^5.70.0"
   },
   "lint-staged": {
-    "*": "prettier --write"
+    "*.{js,ts,jsx,tsx,json,md,css,scss,yml}": "prettier --write"
   }
 }


### PR DESCRIPTION
Sorry, the precommit hook failed while trying to format some unsupported files which blocks the commit:

>  [error] No parser could be inferred for file: sentry.properties

We should limit prettier to parse only selected file extensions.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
