### PR TITLE
Skip remaining generic paths

### DIFF
--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -71,7 +71,14 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
 }
 
 export async function getStaticPaths() {
-  const SKIP_GENERIC_PATHS = ["/", "topplista"];
+  const SKIP_GENERIC_PATHS = [
+    "/",
+    "topplista",
+    "artikler",
+    "om",
+    "ofte-stilte-sporsmal",
+    "vippsavtale",
+  ];
   const data = await getClient(false).fetch<{ pages: Array<{ slug: { current: string } }> }>(
     fetchGenericPages,
   );


### PR DESCRIPTION
Adds remaining custom pages to be ignored by generic page in addition to #677 

- closes #676 

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
