### PR TITLE
Generic articles list component

### DIFF
--- a/components/main/blocks/ArticlesPreviewList/ArticlesPreviewList.module.scss
+++ b/components/main/blocks/ArticlesPreviewList/ArticlesPreviewList.module.scss
@@ -1,0 +1,27 @@
+.articles {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  column-gap: 50px;
+  row-gap: 40px;
+}
+
+.articles li:first-child {
+  grid-column: span 2;
+  grid-row: span 2;
+}
+
+@media only screen and (max-width: 1180px) {
+  .articles {
+    margin-top: 20px;
+    grid-template-columns: 1fr;
+    grid-auto-flow: row;
+    grid-auto-rows: max-content;
+    row-gap: 30px;
+  }
+
+  .articles li:first-child {
+    grid-column: auto;
+    grid-row: auto;
+  }
+}

--- a/components/main/blocks/ArticlesPreviewList/ArticlesPreviewList.tsx
+++ b/components/main/blocks/ArticlesPreviewList/ArticlesPreviewList.tsx
@@ -1,0 +1,44 @@
+import { groq } from "next-sanity";
+import { getClient } from "../../../../lib/sanity.server";
+import { withStaticProps } from "../../../../util/withStaticProps";
+import { ArticlePreview } from "../../layout/RelatedArticles/ArticlePreview";
+import styles from "./ArticlesPreviewList.module.scss";
+
+export const ArticlesPreviewList = withStaticProps(async ({ preview }: { preview: boolean }) => {
+  const result = await getClient(preview).fetch(fetchArticles);
+  const articles = result.articles;
+  return {
+    articles,
+  };
+})(({ articles }) => {
+  return (
+    <div className={styles.articles}>
+      {articles &&
+        articles.map((article: any, i: number) => (
+          <ArticlePreview
+            key={article.slug}
+            header={article.header}
+            inngress={
+              i === 0
+                ? article.header.inngress ||
+                  (article.preview.length > 350
+                    ? article.preview.substr(0, 350) + "..."
+                    : article.preview)
+                : undefined
+            }
+            slug={article.slug}
+          />
+        ))}
+    </div>
+  );
+});
+
+const fetchArticles = groq`
+{
+  "articles": *[_type == "article_page"] | order(header.published desc) {
+    header,
+    "slug": slug.current,
+    "preview": array::join(content[_type == "contentsection"][0].blocks[_type=="paragraph"][0].content[0..3].children[0...3].text, "\n"),
+  }
+}
+`;

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -26,6 +26,7 @@ import { WealthCalculatorTeaser } from "./WealthCalculatorTeaser/WealthCalculato
 import { IntroSection } from "./IntroSection/IntroSection";
 import { OrganizationsList } from "./OrganizationsList/OrganizationsList";
 import { withStaticProps } from "../../../util/withStaticProps";
+import { ArticlesPreviewList } from "./ArticlesPreviewList/ArticlesPreviewList";
 
 type Section = SectionContainerProps & {
   _key: string;
@@ -38,6 +39,9 @@ export const BlockContentRenderer = withStaticProps(
     const promiseMap = blocks.reduce<Map<typeof blocks[number]["_key"], Promise<any>>>(
       (map, block) => {
         switch (block._type) {
+          case "articlespreviewlist": {
+            map.set(block._key, ArticlesPreviewList.getStaticProps({ preview }));
+          }
         }
         return map;
       },
@@ -227,6 +231,9 @@ export const BlockContentRenderer = withStaticProps(
                         organizations={block.organizations}
                       />
                     );
+                  }
+                  case "articlespreviewlist": {
+                    return <ArticlesPreviewList key={block._key} {...parsedMap.get(block._key)} />;
                   }
                   default:
                     return block._type;

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -30,12 +30,12 @@ import { ArticlesPreviewList } from "./ArticlesPreviewList/ArticlesPreviewList";
 
 type Section = SectionContainerProps & {
   _key: string;
-  blocks: Array<Record<string, any> & { _key: string; _type: string }>;
+  blocks?: Array<Record<string, any> & { _key: string; _type: string }>;
 };
 
 export const BlockContentRenderer = withStaticProps(
   async ({ preview, content }: { preview: boolean; content: Section[] }) => {
-    const blocks = content.flatMap((section: Section) => section.blocks);
+    const blocks = content.flatMap((section: Section) => section.blocks || []);
     const promiseMap = blocks.reduce<Map<typeof blocks[number]["_key"], Promise<any>>>(
       (map, block) => {
         switch (block._type) {

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -54,6 +54,8 @@ export const BlockContentRenderer = withStaticProps(
         ),
       ),
     );
+
+    /* getStaticProps must return a serializable object (https://nextjs.org/docs/api-reference/data-fetching/get-static-props#props) */
     const serializedMap = JSON.stringify(Array.from(resolvedMap.entries()));
 
     return {

--- a/components/main/blocks/WealthCalculator/WealthCalculator.tsx
+++ b/components/main/blocks/WealthCalculator/WealthCalculator.tsx
@@ -268,7 +268,7 @@ export const WealthCalculator: React.FC<{
         <>
           <AnimateHeight height={explanationOpen ? "auto" : 0} duration={500}>
             <div data-cy="wealthcalculator-explanation">
-              <BlockContentRenderer content={[explanation]} />
+              <BlockContentRenderer content={[explanation]} data={JSON.stringify([])} />
             </div>
           </AnimateHeight>
         </>

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -12,11 +12,13 @@ import { Layout } from "../components/main/layout/layout";
 import { BlockContentRenderer } from "../components/main/blocks/BlockContentRenderer";
 import { linksContentQuery, pageContentQuery, widgetQuery } from "../_queries";
 import { filterPageToSingleItem } from "./_app";
+import { InferGetStaticPropsType } from "next";
 
-const GenericPage: LayoutPage<{
-  data: { result: { [key: string]: any; page: PageTypes["generic_page"] } };
-  preview: boolean;
-}> = ({ data, preview }) => {
+const GenericPage: LayoutPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
+  data,
+  preview,
+  blocksData,
+}) => {
   const page = data.result.page;
 
   if (!page) {
@@ -48,7 +50,7 @@ const GenericPage: LayoutPage<{
         centered={header.centered}
       />
 
-      <BlockContentRenderer content={content} />
+      <BlockContentRenderer content={content} data={blocksData} />
     </>
   );
 };
@@ -58,6 +60,11 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
   let result = await getClient(preview).fetch(fetchGenericPage, { slug });
   result = { ...result, page: filterPageToSingleItem(result, preview) };
 
+  const { data: blocksData } = await BlockContentRenderer.getStaticProps({
+    preview,
+    content: result.page.content,
+  });
+
   return {
     props: {
       preview: preview,
@@ -66,6 +73,7 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
         query: fetchGenericPage,
         queryParams: { slug },
       },
+      blocksData,
     },
   };
 }

--- a/pages/[slug].tsx
+++ b/pages/[slug].tsx
@@ -62,7 +62,7 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
 
   const { data: blocksData } = await BlockContentRenderer.getStaticProps({
     preview,
-    content: result.page.content,
+    content: result.page.content || [],
   });
 
   return {

--- a/pages/artikler/[slug].tsx
+++ b/pages/artikler/[slug].tsx
@@ -63,7 +63,7 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
 
   const { data: blocksData } = await BlockContentRenderer.getStaticProps({
     preview,
-    content: result.page.content,
+    content: result.page.content || [],
   });
 
   return {

--- a/pages/artikler/[slug].tsx
+++ b/pages/artikler/[slug].tsx
@@ -13,8 +13,13 @@ import { Layout } from "../../components/main/layout/layout";
 import { BlockContentRenderer } from "../../components/main/blocks/BlockContentRenderer";
 import { pageContentQuery, widgetQuery } from "../../_queries";
 import { filterPageToSingleItem } from "../_app";
+import { InferGetStaticPropsType } from "next";
 
-const ArticlePage: LayoutPage<{ data: any; preview: boolean }> = ({ data, preview }) => {
+const ArticlePage: LayoutPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
+  data,
+  preview,
+  blocksData,
+}) => {
   const page = data.result.page;
 
   if (!page) {
@@ -45,7 +50,7 @@ const ArticlePage: LayoutPage<{ data: any; preview: boolean }> = ({ data, previe
 
       <ArticleHeader title={header.title} inngress={header.inngress} published={header.published} />
 
-      <BlockContentRenderer content={content} />
+      <BlockContentRenderer content={content} data={blocksData} />
       <RelatedArticles relatedArticles={relatedArticles} />
     </>
   );
@@ -56,6 +61,11 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
   let result = await getClient(preview).fetch(fetchArticle, { slug });
   result = { ...result, page: filterPageToSingleItem(result, preview) };
 
+  const { data: blocksData } = await BlockContentRenderer.getStaticProps({
+    preview,
+    content: result.page.content,
+  });
+
   return {
     props: {
       preview: preview,
@@ -64,6 +74,7 @@ export async function getStaticProps({ preview = false, params = { slug: "" } })
         query: fetchArticle,
         queryParams: { slug },
       },
+      blocksData,
     },
   };
 }

--- a/pages/vippsavtale.tsx
+++ b/pages/vippsavtale.tsx
@@ -20,8 +20,13 @@ import {
 import { useAuth0 } from "@auth0/auth0-react";
 import { BlockContentRenderer } from "../components/main/blocks/BlockContentRenderer";
 import LinkButton from "../components/shared/components/EffektButton/LinkButton";
+import { InferGetStaticPropsType } from "next";
 
-const VippsAgreement: LayoutPage<{ data: any; preview: boolean }> = ({ data, preview }) => {
+const VippsAgreement: LayoutPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
+  data,
+  preview,
+  blocksData,
+}) => {
   const { loginWithRedirect } = useAuth0();
 
   const page = data.result.page;
@@ -72,7 +77,7 @@ const VippsAgreement: LayoutPage<{ data: any; preview: boolean }> = ({ data, pre
           <LinkButton title={"Logg inn"} type={"primary"} url={`/min-side`} />
         </div>
       </SectionContainer>
-      <BlockContentRenderer content={page.content} />
+      <BlockContentRenderer content={page.content} data={blocksData} />
     </>
   );
 };
@@ -80,6 +85,11 @@ const VippsAgreement: LayoutPage<{ data: any; preview: boolean }> = ({ data, pre
 export async function getStaticProps({ preview = false }) {
   let result = await getClient(preview).fetch(fetchVippsAgreementPage);
   result = { ...result, page: filterPageToSingleItem(result, preview) };
+
+  const { data: blocksData } = await BlockContentRenderer.getStaticProps({
+    preview,
+    content: result.page.content,
+  });
 
   return {
     props: {
@@ -89,6 +99,7 @@ export async function getStaticProps({ preview = false }) {
         query: fetchVippsAgreementPage,
         queryParams: {},
       },
+      blocksData,
     },
   };
 }

--- a/pages/vippsavtale.tsx
+++ b/pages/vippsavtale.tsx
@@ -88,7 +88,7 @@ export async function getStaticProps({ preview = false }) {
 
   const { data: blocksData } = await BlockContentRenderer.getStaticProps({
     preview,
-    content: result.page.content,
+    content: result.page.content || [],
   });
 
   return {

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -53,6 +53,7 @@ import newslettersignup from "./types/newslettersignup";
 import wealthcalculator from "./types/wealthcalculator";
 import wealthcalculatorteaser from "./types/wealthcalculatorteaser";
 import organizationslist from "./types/organizationslist";
+import articlespreviewlist from "./types/articlespreviewlist";
 
 export const pages = [
   generic,
@@ -107,6 +108,7 @@ export const types = [
   wealthcalculator,
   wealthcalculatorteaser,
   organizationslist,
+  articlespreviewlist,
 ] as const;
 
 // Then we give our schema to the builder and provide the result to Sanity

--- a/studio/schemas/types/articlespreviewlist.ts
+++ b/studio/schemas/types/articlespreviewlist.ts
@@ -1,0 +1,25 @@
+import { Grid } from "react-feather";
+
+export default {
+  name: "articlespreviewlist",
+  type: "object",
+  title: "Articles preview list",
+  icon: Grid,
+  fields: [
+    // hidden field
+    {
+      name: "empty",
+      type: "boolean",
+      title: "Empty",
+      hidden: true,
+      initialValue: false,
+    },
+  ],
+  preview: {
+    prepare() {
+      return {
+        title: "All articles",
+      };
+    },
+  },
+} as const;

--- a/studio/schemas/types/contentsection.ts
+++ b/studio/schemas/types/contentsection.ts
@@ -50,6 +50,7 @@ export default {
         { type: "wealthcalculator" },
         { type: "htmlembed" },
         { type: "organizationslist" },
+        { type: "articlespreviewlist" },
       ],
       options: {
         editModal: "fullscreen",

--- a/util/withStaticProps.ts
+++ b/util/withStaticProps.ts
@@ -1,0 +1,9 @@
+export const withStaticProps =
+  <Context, StaticProps>(getStaticProps: (context: Context) => Promise<StaticProps>) =>
+  <Props = {}>(
+    component: React.FC<Props & StaticProps>,
+  ): React.FC<Props & StaticProps> & {
+    getStaticProps: (context: Context) => Promise<StaticProps>;
+  } => {
+    return Object.assign(component, { getStaticProps });
+  };


### PR DESCRIPTION
Since we want to fetch all articles for preview on the articles page, we need some way to fetch static props dynamically based on page content. The idea of this approach is to have components expose some `getStaticProps` function that is called from page `getStaticProps`. It adds some boilerplate, but I think it could be useful in other scenarios where we want to decouple data fetching to page components.

- closes #684

---

Tested on devices

- [x] Desktop 💻
- [x] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
