### PR TITLE
Remove filter page option

### DIFF
--- a/pages/[[...slug]].page.tsx
+++ b/pages/[[...slug]].page.tsx
@@ -42,9 +42,7 @@ export const getStaticProps = async ({
   preview = false,
   params,
 }: GetStaticPropsContext<{ slug: string[] }>) => {
-  const appStaticProps = await getAppStaticProps({
-    filterPage: true,
-  });
+  const appStaticProps = await getAppStaticProps();
 
   const path = params?.slug ?? [];
 

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -57,10 +57,6 @@ function MyApp({
 
     const widgetData = filterWidgetToSingleItem(previewData, pageProps.preview);
 
-    if (appStaticProps?.filterPage) {
-      pageProps.data.result.page = filterPageToSingleItem(previewData, pageProps.preview);
-    }
-
     return (
       <Provider store={store}>
         <RouterContext.Provider value={appStaticProps?.routerContext || null}>
@@ -75,12 +71,11 @@ function MyApp({
   }
 }
 
-export async function getAppStaticProps(options?: { layout?: LayoutType; filterPage?: boolean }) {
+export async function getAppStaticProps(options?: { layout?: LayoutType }) {
   const routerContext = await fetchRouterContext();
   const appStaticProps = {
     routerContext,
     layout: options?.layout ?? LayoutType.Default,
-    filterPage: options?.filterPage ?? false,
   };
   return appStaticProps;
 }

--- a/pages/vippsavtale.page.tsx
+++ b/pages/vippsavtale.page.tsx
@@ -83,9 +83,7 @@ export const getStaticProps = async ({
   preview = false,
   params,
 }: GetStaticPropsContext<{ slug: string[] }>) => {
-  const appStaticProps = await getAppStaticProps({
-    filterPage: true,
-  });
+  const appStaticProps = await getAppStaticProps();
   let result = await getClient(preview).fetch(fetchVippsAgreementPage);
   result = { ...result, page: filterPageToSingleItem(result, preview) };
 


### PR DESCRIPTION
It seems to me like we already do this in page get static props, so this should be redundant

---

Tested on devices

- [x] Desktop 💻
- [x] Mobile 📱

Tests

- [x] All tests are running ✔️
- [x] Test are updated 🧪
- [x] Code Review 👩‍💻
- [x] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
