### PR TITLE
Nested generic paths

### DIFF
--- a/pages/GenericPage.tsx
+++ b/pages/GenericPage.tsx
@@ -12,13 +12,11 @@ import { widgetQuery, linksContentQuery, pageContentQuery } from "../_queries";
 import { footerQuery } from "../components/shared/layout/Footer/Footer";
 
 export const getGenericPagePaths = async () => {
-  const SKIP_GENERIC_PATHS = ["om", "vippsavtale"];
   const data = await getClient(false).fetch<{ pages: Array<{ slug: { current: string } }> }>(
     fetchGenericPages,
   );
   const slugs = data.pages.map((page) => page.slug.current);
-  const filteredSlugs = slugs.filter((slug) => !SKIP_GENERIC_PATHS.includes(slug));
-  const paths = filteredSlugs.map((slug) => [slug === "/" ? "" : slug]);
+  const paths = slugs.map((slug) => [slug === "/" ? "" : slug]);
   return paths;
 };
 

--- a/pages/GenericPage.tsx
+++ b/pages/GenericPage.tsx
@@ -16,12 +16,13 @@ export const getGenericPagePaths = async () => {
     fetchGenericPages,
   );
   const slugs = data.pages.map((page) => page.slug.current);
-  const paths = slugs.map((slug) => [slug === "/" ? "" : slug]);
+  const paths = slugs.map((slug) => slug.split("/"));
   return paths;
 };
 
 export const GenericPage = withStaticProps(
-  async ({ preview, slug }: { preview: boolean; slug: string }) => {
+  async ({ preview, path }: { preview: boolean; path: string[] }) => {
+    const slug = path.join("/") || "/";
     let result = await getClient(preview).fetch(fetchGenericPage, { slug });
     result = { ...result, page: filterPageToSingleItem(result, preview) };
 

--- a/pages/[[...slug]].page.tsx
+++ b/pages/[[...slug]].page.tsx
@@ -52,8 +52,7 @@ export const getStaticProps = async ({
 
   switch (pageType) {
     case PageType.GenericPage: {
-      const slug = path[0] ?? "/";
-      const props = await GenericPage.getStaticProps({ preview, slug });
+      const props = await GenericPage.getStaticProps({ preview, path });
       return {
         props: {
           ...props,

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -46,6 +46,7 @@ function MyApp({
   const PageLayout = { [LayoutType.Default]: Layout, [LayoutType.Profile]: ProfileLayout }[
     appStaticProps?.layout || LayoutType.Default
   ];
+
   const { data: previewData } = usePreviewSubscription(propsData?.query, {
     params: propsData?.queryParams ?? {},
     initialData: propsData?.result,


### PR DESCRIPTION
With some minor modification we can enable nested slugs on generic pages

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
