### PR TITLE
Adds basic configuration for donations details in Sanity

### DIFF
--- a/components/profile/donations/DonationImpact/DonationImpactItem.tsx
+++ b/components/profile/donations/DonationImpact/DonationImpactItem.tsx
@@ -13,6 +13,8 @@ export type ImpactItemConfiguration = {
   output_subheading_format_string: string;
   missing_evaluation_header: string;
   missing_impact_evaluation_text: any[];
+  about_org_link_title_format_string: string;
+  about_org_link_url_format_string: string;
   currency: string;
   locale: string;
 };
@@ -209,17 +211,13 @@ export const DonationImpactItem: React.FC<{
                     {
                       _type: "link",
                       _key: "charity_description",
-                      title: "Om " + relevantEvaluation.charity.charity_name,
-                      url:
-                        "https://gieffektivt.no/topplista#" +
-                        relevantEvaluation.charity.charity_name.replaceAll(" ", "_"),
-                      newtab: true,
-                    },
-                    {
-                      _type: "link",
-                      _key: "giveWell",
-                      title: "GiveWell’s analyser",
-                      url: "https://www.givewell.org/how-we-work/our-criteria/cost-effectiveness/cost-effectiveness-models",
+                      title: configuration.about_org_link_title_format_string.replace(
+                        "{{org}}",
+                        relevantEvaluation.charity.charity_name,
+                      ),
+                      url: configuration.about_org_link_url_format_string
+                        .replace("{{org}}", relevantEvaluation.charity.charity_name)
+                        .replaceAll(" ", "_"),
                       newtab: true,
                     },
                   ]}

--- a/components/profile/donations/DonationImpact/DonationImpactItem.tsx
+++ b/components/profile/donations/DonationImpact/DonationImpactItem.tsx
@@ -5,8 +5,17 @@ import useSWR from "swr";
 import { ImpactEvaluation } from "../../../../models";
 import AnimateHeight from "react-animate-height";
 import { Links } from "../../../main/blocks/Links/Links";
+import { PortableText } from "@portabletext/react";
 
 const fetcher = (url: string) => fetch(url).then((res) => res.json());
+
+export type ImpactItemConfiguration = {
+  output_subheading_format_string: string;
+  missing_evaluation_header: string;
+  missing_impact_evaluation_text: any[];
+  currency: string;
+  locale: string;
+};
 
 export const DonationImpactItem: React.FC<{
   orgAbriv: string;
@@ -14,9 +23,21 @@ export const DonationImpactItem: React.FC<{
   donationTimestamp: Date;
   precision: number;
   signalRequiredPrecision: (precision: number) => void;
-}> = ({ orgAbriv, sumToOrg, donationTimestamp, precision, signalRequiredPrecision }) => {
+  configuration: ImpactItemConfiguration;
+}> = ({
+  orgAbriv,
+  sumToOrg,
+  donationTimestamp,
+  precision,
+  signalRequiredPrecision,
+  configuration,
+}) => {
   const { data, error, isValidating } = useSWR<{ evaluations: ImpactEvaluation[] }>(
-    `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${orgAbriv}&currency=NOK&language=NO&donation_year=${donationTimestamp.getFullYear()}&donation_month=${
+    `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${orgAbriv}&currency=${
+      configuration.currency
+    }&language=${
+      configuration.locale
+    }&donation_year=${donationTimestamp.getFullYear()}&donation_month=${
       donationTimestamp.getMonth() + 1
     }`,
     fetcher,
@@ -67,14 +88,19 @@ export const DonationImpactItem: React.FC<{
           </td>
           <td>
             <div className={style.impactContext}>
-              <span className={style.impactDetailsDescription}>kr til {orgAbriv}</span>
+              <span className={style.impactDetailsDescription}>
+                {" "}
+                {configuration.output_subheading_format_string
+                  .replace("{{sum}}", thousandize(sumToOrg))
+                  .replace("{{org}}", orgAbriv)}
+              </span>
               <span
                 className={[style.impactDetailsExpandText, showDetails ? style.expanded : ""].join(
                   " ",
                 )}
                 onClick={() => setShowDetails(!showDetails)}
               >
-                Ingen relevant evaluering tilgjengelig for å beregne effekt
+                {configuration.missing_evaluation_header}
               </span>
             </div>
           </td>
@@ -84,6 +110,8 @@ export const DonationImpactItem: React.FC<{
             {/* Strange hack required to not have table reflow when showing the animated area */}
             <AnimateHeight duration={300} animateOpacity height={showDetails ? "auto" : 0}>
               <div>
+                <PortableText value={configuration.missing_impact_evaluation_text} />
+                {/*
                 <p>
                   For denne intervensjonen har vi ikke lagt inn en relevant evaluering fra GiveWell
                   for tidsrommet donasjonen er gitt. Dette kan skyldes at vi ikke har oppdaterte
@@ -109,6 +137,7 @@ export const DonationImpactItem: React.FC<{
                     ]}
                   />
                 </div>
+                */}
               </div>
             </AnimateHeight>
           </td>
@@ -155,9 +184,15 @@ export const DonationImpactItem: React.FC<{
               )}
               onClick={() => setShowDetails(!showDetails)}
             >
-              {`${thousandize(Math.round(sumToOrg))} kr til ${
+              {/** {{sum}} for sum and {{org}} for charity name in template string */}
+              {configuration.output_subheading_format_string
+                .replace("{{sum}}", thousandize(sumToOrg))
+                .replace("{{org}}", relevantEvaluation.charity.charity_name)}
+              {/*
+              `${thousandize(Math.round(sumToOrg))} kr til ${
                 relevantEvaluation.charity.charity_name
-              }`}
+              }`
+            */}
             </span>
           </div>
         </td>
@@ -168,15 +203,6 @@ export const DonationImpactItem: React.FC<{
           <AnimateHeight duration={300} animateOpacity height={showDetails ? "auto" : 0}>
             <div>
               <p>{relevantEvaluation.intervention.long_description}</p>
-              <p>
-                Tallene er basert på analysene til GiveWell. De gir et omtrentlig bilde på hva våre
-                anbefalte organisasjoner får ut av pengene. Tiltaket er topp anbefalt som en av de
-                mest kostnadseffektive måtene å redde liv eller forbedre den økonomiske situasjonen
-                til ekstremt fattige. Mange bistandsorganisasjoner viser til overdrevne og
-                misvisende tall i sin markedsføring. Bak våre tall ligger tusenvis av timer med
-                undersøkelser og inkluderer alle kostnader, inkludert planlegging, innkjøp,
-                distribusjon, opplæring og kontroll.
-              </p>
               <div>
                 <Links
                   links={[

--- a/components/profile/donations/DonationsAggregateImpactTable/DonationsAggregateImpactTable.tsx
+++ b/components/profile/donations/DonationsAggregateImpactTable/DonationsAggregateImpactTable.tsx
@@ -15,21 +15,21 @@ const multiFetcher = (...urls: string[]) => {
   return Promise.all(urls.map(f));
 };
 
-export type AggregatedImpactTableTexts = {
+export type AggregatedImpactTableConfiguration = {
   title: string;
-  impact_locale: string;
   org_grant_template_string: string;
   org_direct_template_string: string;
   org_operations_string: string;
+  currency: string;
+  locale: string;
 };
 
 export const DonationsAggregateImpactTable: React.FC<{
   donations: Donation[];
   distributionMap: Map<string, Distribution>;
-  texts: AggregatedImpactTableTexts;
-  currency: string;
+  configuration: AggregatedImpactTableConfiguration;
   defaultExpanded?: boolean;
-}> = ({ donations, distributionMap, texts, currency, defaultExpanded = true }) => {
+}> = ({ donations, distributionMap, configuration, defaultExpanded = true }) => {
   const [expanded, setExpanded] = useState(
     defaultExpanded || (typeof window !== "undefined" && window.innerWidth > 1180),
   );
@@ -44,7 +44,7 @@ export const DonationsAggregateImpactTable: React.FC<{
     error: impacterror,
     isValidating: impactvalidating,
   } = useSWR<{ max_impact_fund_grants: GiveWellGrant[] }>(
-    `https://impact.gieffektivt.no/api/max_impact_fund_grants?currency=${currency}&language=${texts.impact_locale}`,
+    `https://impact.gieffektivt.no/api/max_impact_fund_grants?currency=${configuration.currency}&language=${configuration.locale}`,
     fetcher,
     {
       revalidateIfStale: false,
@@ -67,9 +67,11 @@ export const DonationsAggregateImpactTable: React.FC<{
       const year = key.split("-")[0];
       const month = key.split("-")[1];
       urls.push(
-        `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${abbriv}&currency=${currency}&language=${
-          texts.impact_locale
-        }&donation_year=${year}&donation_month=${parseInt(month) + 1}`,
+        `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${abbriv}&currency=${
+          configuration.currency
+        }&language=${configuration.locale}&donation_year=${year}&donation_month=${
+          parseInt(month) + 1
+        }`,
       );
     }
   }
@@ -103,8 +105,8 @@ export const DonationsAggregateImpactTable: React.FC<{
   let loading = true;
   let mappedEvaluations = [];
   let templateStrings = {
-    org_direct_template_string: texts.org_direct_template_string,
-    org_grant_template_string: texts.org_grant_template_string,
+    org_direct_template_string: configuration.org_direct_template_string,
+    org_grant_template_string: configuration.org_grant_template_string,
   };
   if (impactdata && !impactvalidating && evaluationdata && !evaluationvalidating) {
     mappedEvaluations = evaluationdata.map((d) => d.evaluations).flat();
@@ -161,7 +163,7 @@ export const DonationsAggregateImpactTable: React.FC<{
         }}
       >
         <span>
-          {texts.title}
+          {configuration.title}
           <div className={style.loadingSpinner}>
             <LoadingButtonSpinner />
           </div>

--- a/components/profile/shared/lists/donationList/DonationDetails.module.scss
+++ b/components/profile/shared/lists/donationList/DonationDetails.module.scss
@@ -33,3 +33,35 @@
 .actions ul li span {
   text-decoration: underline;
 }
+
+.caption {
+  cursor: pointer;
+  user-select: none;
+  font-size: 0.8rem;
+  display: block;
+}
+
+.caption::after {
+  content: "↓";
+  display: inline-block;
+  transition: transform 200ms;
+  transform: rotate(0deg);
+}
+
+.captionopen::after {
+  transform: rotate(180deg);
+}
+
+.impactExplanationContainer {
+  display: flex;
+  padding-top: 1rem;
+  padding-bottom: 0;
+  padding-left: 2rem;
+  flex-direction: column;
+  border-left: 1px solid var(--primary);
+  margin-top: 1rem;
+}
+
+.impactExplanationContainer p {
+  margin: 0;
+}

--- a/components/profile/shared/lists/donationList/DonationDetails.tsx
+++ b/components/profile/shared/lists/donationList/DonationDetails.tsx
@@ -1,15 +1,32 @@
-import React from "react";
+import React, { useState } from "react";
 import style from "./DonationDetails.module.scss";
 import { Distribution, Donation } from "../../../../../models";
-import DonationImpact from "../../../donations/DonationImpact/DonationImpact";
+import DonationImpact, {
+  DonationImpactItemsConfiguration,
+} from "../../../donations/DonationImpact/DonationImpact";
 import { mapNameToOrgAbbriv } from "../../../../../util/mappings";
+import AnimateHeight from "react-animate-height";
+import { LinkType, Links } from "../../../../main/blocks/Links/Links";
+import { PortableText } from "@portabletext/react";
+import { NavLink } from "../../../../main/layout/navbar";
+
+export type DonationDetailsConfiguration = {
+  impact_estimate_header: string;
+  impact_estimate_explanation_title: string;
+  impact_estimate_explanation_text: any[];
+  impact_estimate_explanation_links: (LinkType | NavLink)[];
+  impact_items_configuration: DonationImpactItemsConfiguration;
+};
 
 export const DonationDetails: React.FC<{
   sum: string;
   donation: Donation;
   distribution: Distribution;
   timestamp: Date;
-}> = ({ sum, donation, distribution, timestamp }) => {
+  configuration: DonationDetailsConfiguration;
+}> = ({ sum, donation, distribution, timestamp, configuration }) => {
+  const [showImpactEstimateExplanation, setShowImpactEstimateExplanation] = useState(false);
+
   if (!distribution)
     return <span>Ingen distribusjon funnet for donasjon med KID {donation.KID}</span>;
 
@@ -21,28 +38,39 @@ export const DonationDetails: React.FC<{
   return (
     <div className={style.wrapper}>
       <div className={style.impactEstimate}>
-        <strong>Estimert effekt</strong>
-        {/** Custom caching WIP */}
-        {/* <SWRConfig value={{ provider: () => ImpactCache }}> */}
+        <strong>{configuration.impact_estimate_header}</strong>
+        <span
+          className={
+            showImpactEstimateExplanation
+              ? [style.caption, style.captionopen].join(" ")
+              : style.caption
+          }
+          onClick={() => setShowImpactEstimateExplanation(!showImpactEstimateExplanation)}
+        >
+          {configuration.impact_estimate_explanation_title}&nbsp;&nbsp;
+        </span>
+        <AnimateHeight duration={500} height={showImpactEstimateExplanation ? "auto" : 0}>
+          <div className={style.impactExplanationContainer}>
+            <PortableText value={configuration?.impact_estimate_explanation_text} />
+            <Links links={configuration?.impact_estimate_explanation_links}></Links>
+          </div>
+        </AnimateHeight>
+
         <DonationImpact
           donation={donation}
           distribution={mappedDistribution}
           timestamp={timestamp}
+          configuration={configuration.impact_items_configuration}
         />
-        {/*</SWRConfig>*/}
       </div>
 
       <div className={style.actions}>
-        {/*<strong>Handlinger</strong>*/}
-        <ul>
-          {/**
-           *           <li>
-            <a href="#">
-              <FileText size={16} color={"black"} /> <span>Kvittering</span>
-            </a>
-          </li>
-           */}
-        </ul>
+        {/**
+         * TODO: Add actions for managing the donation
+         * - Download receipt
+         * - Connect to tax unit
+         * - Edit agreement (if it is an agreement)
+         */}
       </div>
     </div>
   );

--- a/components/profile/shared/lists/donationList/DonationList.tsx
+++ b/components/profile/shared/lists/donationList/DonationList.tsx
@@ -1,8 +1,9 @@
 import { Distribution, Donation } from "../../../../../models";
 import { onlyDate, thousandize } from "../../../../../util/formatting";
+import { ErrorMessage } from "../../ErrorMessage/ErrorMessage";
 import { GenericList } from "../GenericList";
 import { ListRow } from "../GenericListRow";
-import { DonationDetails } from "./DonationDetails";
+import { DonationDetails, DonationDetailsConfiguration } from "./DonationDetails";
 
 export type TableFieldTypes = "string" | "sum" | "date" | "paymentmethod";
 
@@ -20,8 +21,9 @@ export const DonationList: React.FC<{
   distributions: Map<string, Distribution>;
   year: string;
   configuration: DonationsListConfiguration;
+  detailsConfiguration?: DonationDetailsConfiguration;
   firstOpen: boolean;
-}> = ({ donations, distributions, year, configuration, firstOpen }) => {
+}> = ({ donations, distributions, year, configuration, detailsConfiguration, firstOpen }) => {
   let taxDeductionText: JSX.Element | undefined = undefined;
 
   let taxDeductions = 0;
@@ -71,14 +73,17 @@ export const DonationList: React.FC<{
       cells: configuration.columns.map((column) => ({
         value: formatField(donation[column.value], column.type),
       })),
-      details: (
+      details: detailsConfiguration ? (
         <DonationDetails
           key={donation.id}
           donation={donation}
           sum={donation.sum}
           distribution={distributions.get(donation.KID.trim()) as Distribution}
           timestamp={new Date(donation.timestamp)}
+          configuration={detailsConfiguration}
         />
+      ) : (
+        <ErrorMessage>Missing donation details configuration in Sanity</ErrorMessage>
       ),
       element: donation,
     };

--- a/studio/schemas/dashboard/donations.ts
+++ b/studio/schemas/dashboard/donations.ts
@@ -34,6 +34,78 @@ export default {
       type: "donationstableconfiguration",
     },
     {
+      name: "donations_details_configuration",
+      title: "Donations table details configuration",
+      description: "Configuration for the expanded view of the donations table",
+      type: "object",
+      fields: [
+        {
+          name: "impact_estimate_header",
+          title: "Impact estimate header",
+          type: "string",
+        },
+        {
+          name: "impact_estimate_explanation_title",
+          title: "Impact estimate explanation title",
+          type: "string",
+        },
+        {
+          name: "impact_estimate_explanation_text",
+          title: "Impact estimate explanation text",
+          type: "array",
+          of: [{ type: "block" }],
+        },
+        {
+          name: "impact_estimate_explanation_links",
+          title: "Impact estimate explanation links",
+          type: "array",
+          of: [{ type: "link" }, { type: "navitem" }],
+        },
+        {
+          name: "impact_items_configuration",
+          title: "Impact items configuration",
+          type: "object",
+          fields: [
+            {
+              name: "smart_distribution_label",
+              title: "Smart distribution label",
+              type: "string",
+            },
+            {
+              name: "operations_label",
+              title: "Operations label",
+              type: "string",
+            },
+            {
+              name: "impact_item_configuration",
+              title: "Impact item configuration",
+              type: "object",
+              fields: [
+                {
+                  name: "output_subheading_format_string",
+                  title: "Output subheading format string",
+                  type: "string",
+                  description:
+                    "Use {{sum}} insert the donation sum to the organization, and {{org}} to insert the organization name",
+                },
+                {
+                  name: "missing_evaluation_header",
+                  title: "Missing evaluation header",
+                  type: "string",
+                },
+                {
+                  name: "missing_impact_evaluation_text",
+                  title: "Missing impact evaluation text",
+                  type: "array",
+                  of: [{ type: "block" }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    {
       name: "slug",
       title: "Slug",
       type: "slug",

--- a/studio/schemas/dashboard/donations.ts
+++ b/studio/schemas/dashboard/donations.ts
@@ -99,6 +99,18 @@ export default {
                   type: "array",
                   of: [{ type: "block" }],
                 },
+                {
+                  name: "about_org_link_title_format_string",
+                  title: "About org link title format string",
+                  type: "string",
+                  description: "Use {{org}} to insert the organization name",
+                },
+                {
+                  name: "about_org_link_url_format_string",
+                  title: "About org link url format string",
+                  type: "string",
+                  description: "Use {{org}} to insert the organization name",
+                },
               ],
             },
           ],

--- a/studio/schemas/siteSettings.ts
+++ b/studio/schemas/siteSettings.ts
@@ -49,6 +49,20 @@ export default {
       },
     },
     {
+      name: "main_locale",
+      title: "Main Locale",
+      type: "string",
+      validation: (Rule: any) => Rule.required(),
+      options: {
+        list: [
+          { title: "English", value: "en" },
+          { title: "Norwegian", value: "no" },
+          { title: "Swedish", value: "se" },
+          { title: "Estonian", value: "et" },
+        ],
+      },
+    },
+    {
       title: "Footer column 1",
       name: "footer_column_1",
       description: "Select links for the first footer column",

--- a/studio/schemas/types/aggregateestimatedimpact.ts
+++ b/studio/schemas/types/aggregateestimatedimpact.ts
@@ -10,20 +10,6 @@ export default {
       validation: (Rule: any) => Rule.required(),
     },
     {
-      name: "impact_locale",
-      title: "Impact Locale",
-      type: "string",
-      validation: (Rule: any) => Rule.required(),
-      options: {
-        list: [
-          { title: "English", value: "en" },
-          { title: "Norwegian", value: "no" },
-          { title: "Swedish", value: "se" },
-          { title: "Estonian", value: "et" },
-        ],
-      },
-    },
-    {
       name: "org_grant_template_string",
       title: "Org Grant Template String",
       type: "string",


### PR DESCRIPTION
Adds configuration for impact estimates in details view for Donation page.
Also restructures a bit and moves the currency selection into main page settings.

- [x] Impact explenation (move and put in Sanity)
- [x] Impact element
  - [x] Update fetching to respect currency and language
  - [x] Put all the strings for headers and such in sanity
  - [x] Add missing evaluation texts to Sanity
  - [x] Add the links for each org in Sanity

- closes #738 
- closes #516 

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
