### PR TITLE
Fixes AnimateHeight prop input

### DIFF
--- a/components/main/layout/navbar.tsx
+++ b/components/main/layout/navbar.tsx
@@ -98,7 +98,7 @@ export const Navbar: React.FC<MainNavbarProps> = ({ elements, logo }) => {
                 <button onClick={() => toggleExpanded(el._key)} tabIndex={-1}>
                   {el.title}
                 </button>
-                <AnimateHeight height={expandedSubmenu[el._key] ? "auto" : "0%"} animateOpacity>
+                <AnimateHeight height={expandedSubmenu[el._key] ? "auto" : 0} animateOpacity>
                   <div className={styles.submenu}>
                     <ul>
                       {el.items &&

--- a/components/profile/layout/navbar.tsx
+++ b/components/profile/layout/navbar.tsx
@@ -86,7 +86,7 @@ export const Navbar: React.FC<ProfileNavbarProps> = ({ elements, logo }) => {
                 <button onClick={() => toggleExpanded(el._key)} tabIndex={-1}>
                   {el.title}
                 </button>
-                <AnimateHeight height={expandedSubmenu[el._key] ? "auto" : "0%"} animateOpacity>
+                <AnimateHeight height={expandedSubmenu[el._key] ? "auto" : 0} animateOpacity>
                   <div className={styles.submenu}>
                     <ul>
                       {el.items &&

--- a/components/shared/components/Expander/Expander.tsx
+++ b/components/shared/components/Expander/Expander.tsx
@@ -26,7 +26,7 @@ export const Expander: React.FC<ExpanderProps> = ({ title, content, links }) => 
         {expanded ? <Minus size={28} /> : <Plus size={28} />}
       </label>
       <div className={elements.expanderContent}>
-        <AnimateHeight height={expanded ? "auto" : "0%"} animateOpacity>
+        <AnimateHeight height={expanded ? "auto" : 0} animateOpacity>
           <p>{content}</p>
           {links ? (
             <>


### PR DESCRIPTION
FAQ elements don't open currently. It was related to a package upgrade, which seems to have broken 0% as an input. Should input 0 instead of "0%" to animate height. Might also have broken mobile menus!

---

Tested on devices

- [x] Desktop 💻
- [x] Mobile 📱

Tests

- [x] All tests are running ✔️
- [x] Test are updated 🧪
- [x] Code Review 👩‍💻
- [x] QA 👌

⏲️ Time spent on CR:

⏲️ Time spent on QA:
