### PR TITLE
Feature dynamic preview url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@observablehq/plot": "^0.6.8",
         "@portabletext/react": "^2.0.0",
         "@redux-devtools/extension": "^3.2.5",
-        "@sanity/cli": "^2.30.0",
         "@sanity/image-url": "^1.0.2",
         "@ssfbank/norwegian-id-validators": "^1.0.0",
         "auth0": "^3.2.0",
@@ -1952,17 +1951,6 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.1.tgz",
       "integrity": "sha512-RkmuBcqiNioeeBKbgzMlOdreUkJfYaSjwgx9XDgGGpjvWgyaxWvDmZVSN9CS6LjEASadhgPv2BcFp+SeouWXXA==",
       "dev": true
-    },
-    "node_modules/@sanity/cli": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-2.36.0.tgz",
-      "integrity": "sha512-2U67GANzFVNwTXT+SzMFqamGf8yr+jIW3uIlcjv3b5/04JkmD7oM5YptjsIRIDqqcf/fbxhdjMOuPlCqAE88jA==",
-      "bin": {
-        "sanity": "bin/sanity"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
     },
     "node_modules/@sanity/client": {
       "version": "2.23.2",
@@ -15860,11 +15848,6 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.3.1.tgz",
       "integrity": "sha512-RkmuBcqiNioeeBKbgzMlOdreUkJfYaSjwgx9XDgGGpjvWgyaxWvDmZVSN9CS6LjEASadhgPv2BcFp+SeouWXXA==",
       "dev": true
-    },
-    "@sanity/cli": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@sanity/cli/-/cli-2.36.0.tgz",
-      "integrity": "sha512-2U67GANzFVNwTXT+SzMFqamGf8yr+jIW3uIlcjv3b5/04JkmD7oM5YptjsIRIDqqcf/fbxhdjMOuPlCqAE88jA=="
     },
     "@sanity/client": {
       "version": "2.23.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "echo 'Building Sanity to public/studio' && npm i --prefix studio && npm run build --prefix studio -- ../public/studio -y && echo 'Done'",
+    "prebuild": "echo 'Building Sanity to public/studio' && npm i --prefix studio && cross-env SANITY_STUDIO_SITE_URL=$NEXT_PUBLIC_SITE_URL SANITY_STUDIO_VERCEL_ENV=$VERCEL_ENV SANITY_STUDIO_VERCEL_URL=$VERCEL_URL npm run build --prefix studio -- ../public/studio -y && echo 'Done'",
     "build": "next build",
     "sanity": "dotenv -e .env.local npm run start -- --prefix studio",
     "sanity:edit": "dotenv -e .env.local npm run edit -- --prefix studio",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "echo 'Building Sanity to public/studio' && export SANITY_STUDIO_VERCEL_URL=$VERCEL_URL && cd studio && npm i && npx @sanity/cli build ../public/studio -y && echo 'Done'",
+    "prebuild": "echo 'Building Sanity to public/studio' && npm i --prefix studio && npm run build --prefix studio -- ../public/studio -y && echo 'Done'",
     "build": "next build",
     "sanity": "dotenv -e .env.local npm run start -- --prefix studio",
     "sanity:edit": "dotenv -e .env.local npm run edit -- --prefix studio",
@@ -25,7 +25,6 @@
     "@observablehq/plot": "^0.6.8",
     "@portabletext/react": "^2.0.0",
     "@redux-devtools/extension": "^3.2.5",
-    "@sanity/cli": "^2.30.0",
     "@sanity/image-url": "^1.0.2",
     "@ssfbank/norwegian-id-validators": "^1.0.0",
     "auth0": "^3.2.0",

--- a/studio/env.ts
+++ b/studio/env.ts
@@ -1,0 +1,5 @@
+export const env = {
+  SITE_URL: process.env.SANITY_STUDIO_SITE_URL || "http://localhost:3000",
+  VERCEL_ENV: process.env.SANITY_STUDIO_VERCEL_ENV,
+  VERCEL_URL: process.env.SANITY_STUDIO_VERCEL_URL,
+};

--- a/studio/resolveProductionUrl.ts
+++ b/studio/resolveProductionUrl.ts
@@ -1,8 +1,7 @@
+import { env } from "./env";
+
 export default function resolveProductionUrl(doc: any) {
-  const baseUrl =
-    process.env.VERCEL_ENV === "preview"
-      ? process.env.VERCEL_URL
-      : process.env.NEXT_PUBLIC_SITE_URL || `http://localhost:3000`;
+  const baseUrl = env.VERCEL_ENV === "preview" ? env.VERCEL_URL : env.SITE_URL;
   const previewUrl = new URL(baseUrl);
 
   previewUrl.pathname = `/api/preview`;

--- a/studio/resolveProductionUrl.ts
+++ b/studio/resolveProductionUrl.ts
@@ -1,5 +1,8 @@
 export default function resolveProductionUrl(doc: any) {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || `http://localhost:3000`;
+  const baseUrl =
+    process.env.VERCEL_ENV === "preview"
+      ? process.env.VERCEL_URL
+      : process.env.NEXT_PUBLIC_SITE_URL || `http://localhost:3000`;
   const previewUrl = new URL(baseUrl);
 
   previewUrl.pathname = `/api/preview`;

--- a/studio/resolveProductionUrl.ts
+++ b/studio/resolveProductionUrl.ts
@@ -1,7 +1,5 @@
 export default function resolveProductionUrl(doc: any) {
-  const baseUrl = process.env.SANITY_STUDIO_VERCEL_URL
-    ? `https://${process.env.SANITY_STUDIO_VERCEL_URL}`
-    : `http://localhost:3000`;
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || `http://localhost:3000`;
   const previewUrl = new URL(baseUrl);
 
   previewUrl.pathname = `/api/preview`;


### PR DESCRIPTION
Apparently the VERCEL_URL is not the domain, its just the unique deployment URL. However we could use NEXT_PUBLIC_SITE_URL instead.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

*Check these to flag for a more thurough review, as they could be potentially breaking changes*

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
