### PR TITLE
Adds account number to bank payment method props

### DIFF
--- a/components/shared/components/Widget/components/panes/PaymentPane/Bank/BankPane.tsx
+++ b/components/shared/components/Widget/components/panes/PaymentPane/Bank/BankPane.tsx
@@ -35,6 +35,7 @@ export const BankPane: React.FC<{
             donation={donation}
             accountTitle={config.kontonr_title}
             kidTitle={config.kid_title}
+            accountNr={config.kontonr}
           />
           <InfoText>{config.explanatory_text}</InfoText>
         </div>

--- a/components/shared/components/Widget/components/panes/PaymentPane/Bank/PaymentInformation.tsx
+++ b/components/shared/components/Widget/components/panes/PaymentPane/Bank/PaymentInformation.tsx
@@ -7,13 +7,14 @@ export const PaymentInformation: React.FC<{
   accountTitle: string;
   kidTitle: string;
   donation: Donation;
-}> = ({ donation, accountTitle, kidTitle }) => {
+  accountNr: string;
+}> = ({ donation, accountTitle, kidTitle, accountNr }) => {
   return (
     <>
       <RoundedBorder>
         <TextWrapper>
           <span>{accountTitle}</span>
-          <span>1506 29 95960</span>
+          <span>{accountNr}</span>
         </TextWrapper>
       </RoundedBorder>
       <RoundedBorder>

--- a/components/shared/components/Widget/types/WidgetProps.ts
+++ b/components/shared/components/Widget/types/WidgetProps.ts
@@ -18,6 +18,7 @@ export type BankPaymentMethod = {
   selector_text: string;
   title: string;
   kontonr_title: string;
+  kontonr: string;
   kid_title: string;
   explanatory_text: string;
 };

--- a/studio/schemas/types/paymentmethods/bank.ts
+++ b/studio/schemas/types/paymentmethods/bank.ts
@@ -29,6 +29,12 @@ export default {
       validation: (Rule: any) => Rule.required(),
     },
     {
+      name: "kontonr",
+      title: "Kontonr",
+      type: "string",
+      validation: (Rule: any) => Rule.required(),
+    },
+    {
       name: "kid_title",
       title: "KID title",
       type: "string",


### PR DESCRIPTION
Adds account number as a configurable field to bank payment method

- closes #869 

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
