### PR TITLE
Add redirect /om => /om-oss

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -348,6 +348,7 @@ const nextConfig = {
       { source: "/ge", destination: "/", permanent: true },
       { source: "/filantropi", destination: "/filantropisk-radgivning", permanent: true },
       { source: "/jobba-hos-oss", destination: "/lediga-jobb", permanent: true },
+      { source: "/om", destination: "/om-oss", permanent: true },
       {
         source: "/vi-behoever-prata-om-administrationskostnaderna",
         destination: "/artiklar/vi-maste-prata-om-administrationskostnaderna",


### PR DESCRIPTION
Old SE site has "/om", which is now redirected to "/om-oss"