### PR TITLE
Adds support for yearly or monthly incomes in wealth calculator

### DIFF
--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -191,7 +191,6 @@ export const BlockContentRenderer: React.FC<{ content: any }> = ({ content }) =>
                         );
                       case "wealthcalculator":
                         let calcPeriod: WealthCalculatorPeriodAdjustment;
-                        console.log(block.configuration);
                         if (
                           block.configuration.calculator_input_configuration.period === "yearly"
                         ) {

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -33,6 +33,7 @@ import { SplitViewHtml } from "./SplitViewHtml/SplitViewHtml";
 import { GiftCard } from "./GiftCard/GiftCard";
 import { BlockTables } from "./BlockTable/BlockTables";
 import { DiscountRateComparison } from "./DiscountRateComparison/DiscountRateComparison";
+import { WealthCalculatorPeriodAdjustment } from "../../shared/components/Graphs/Area/AreaGraph";
 
 export const BlockContentRenderer: React.FC<{ content: any }> = ({ content }) => {
   return (
@@ -189,17 +190,38 @@ export const BlockContentRenderer: React.FC<{ content: any }> = ({ content }) =>
                           />
                         );
                       case "wealthcalculator":
+                        let calcPeriod: WealthCalculatorPeriodAdjustment;
+                        console.log(block.configuration);
+                        if (
+                          block.configuration.calculator_input_configuration.period === "yearly"
+                        ) {
+                          calcPeriod = WealthCalculatorPeriodAdjustment.YEARLY;
+                        } else if (
+                          block.configuration.calculator_input_configuration.period === "monthly"
+                        ) {
+                          calcPeriod = WealthCalculatorPeriodAdjustment.MONTHLY;
+                        } else {
+                          return <span>Unknown period {block.period} for wealth calculation</span>;
+                        }
                         return (
                           <WealthCalculator
                             key={block._key || block._id}
                             title={block.title}
                             configuration={block.configuration}
                             intervention_configuration={block.intervention_configuration}
-                            currency={block.currency}
+                            periodAdjustment={calcPeriod}
                             locale={block.locale}
                           />
                         );
                       case "wealthcalculatorteaser":
+                        let teaserPeriod: WealthCalculatorPeriodAdjustment;
+                        if (block.period === "yearly") {
+                          teaserPeriod = WealthCalculatorPeriodAdjustment.YEARLY;
+                        } else if (block.period === "monthly") {
+                          teaserPeriod = WealthCalculatorPeriodAdjustment.MONTHLY;
+                        } else {
+                          return <span>Unknown period {block.period} for wealth calculation</span>;
+                        }
                         return (
                           <WealthCalculatorTeaser
                             key={block._key || block._id}
@@ -215,6 +237,7 @@ export const BlockContentRenderer: React.FC<{ content: any }> = ({ content }) =>
                               block.income_percentile_label_template_string
                             }
                             locale={block.locale}
+                            periodAdjustment={teaserPeriod}
                           />
                         );
                       case "contributorlist":

--- a/components/main/blocks/WealthCalculator/WealthCalculator.tsx
+++ b/components/main/blocks/WealthCalculator/WealthCalculator.tsx
@@ -149,6 +149,7 @@ export const WealthCalculator: React.FC<WealthCalculatorProps> = ({
           postTaxIncome={postTaxIncome}
           wealthMountainGraphData={wealthMountainGraphData}
           equvivalizedIncome={equvivalizedIncome}
+          periodAdjustment={periodAdjustment}
           adjustedPppFactor={pppConversion.adjustedPPPfactor}
           config={slider_configuration}
         />

--- a/components/main/blocks/WealthCalculator/WealthCalculator.tsx
+++ b/components/main/blocks/WealthCalculator/WealthCalculator.tsx
@@ -1,16 +1,14 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import AnimateHeight from "react-animate-height";
 import { useDebouncedCallback } from "use-debounce";
-import { AreaChart } from "../../../shared/components/Graphs/Area/AreaGraph";
-import { BlockContentRenderer } from "../BlockContentRenderer";
 import {
-  InterventionWidgetOutputConfiguration,
-  SanityIntervention,
-} from "../InterventionWidget/InterventionWidgetOutput";
+  AreaChart,
+  WealthCalculatorPeriodAdjustment,
+} from "../../../shared/components/Graphs/Area/AreaGraph";
+import { BlockContentRenderer } from "../BlockContentRenderer";
+import { InterventionWidgetOutputConfiguration } from "../InterventionWidget/InterventionWidgetOutput";
 import { wealthMountainGraphData } from "./data";
 import styles from "./WealthCalculator.module.scss";
-import { LinkType } from "../Links/Links";
-import { NavLink } from "../../../shared/components/Navbar/Navbar";
 import { WealthCalculatorInput, WealthCalculatorInputConfiguration } from "./WealthCalculatorInput";
 import {
   TaxJurisdiction,
@@ -45,7 +43,7 @@ type WealthCalculatorProps = {
     currency: string;
     locale: string;
   };
-  currency: string;
+  periodAdjustment: WealthCalculatorPeriodAdjustment;
   locale: string;
 };
 
@@ -53,7 +51,7 @@ export const WealthCalculator: React.FC<WealthCalculatorProps> = ({
   title,
   configuration,
   intervention_configuration,
-  currency,
+  periodAdjustment,
   locale,
 }) => {
   const {
@@ -108,10 +106,12 @@ export const WealthCalculator: React.FC<WealthCalculatorProps> = ({
       console.error("Unsupported locale", locale);
       return;
     }
-    getEstimatedPostTaxIncome(income / numberOfAdults, taxJurisdiction).then((res) => {
-      setPostTaxIncome(res * numberOfAdults);
-      setLoadingPostTaxIncome(false);
-    });
+    getEstimatedPostTaxIncome(income / numberOfAdults, periodAdjustment, taxJurisdiction).then(
+      (res) => {
+        setPostTaxIncome(res * numberOfAdults);
+        setLoadingPostTaxIncome(false);
+      },
+    );
   }, 250);
 
   useEffect(() => {
@@ -161,11 +161,13 @@ export const WealthCalculator: React.FC<WealthCalculatorProps> = ({
             wealthPercentile={calculateWealthPercentile(
               wealthMountainGraphData,
               equvivalizedIncome || 0,
+              periodAdjustment,
               pppConversion?.adjustedPPPfactor,
             )}
             afterDonationWealthPercentile={calculateWealthPercentile(
               wealthMountainGraphData,
               equvivalizedIncome * (1 - donationPercentage / 100),
+              periodAdjustment,
               pppConversion?.adjustedPPPfactor,
             )}
             afterDonationPercentileLabelTemplateString={
@@ -173,6 +175,7 @@ export const WealthCalculator: React.FC<WealthCalculatorProps> = ({
             }
             incomePercentileLabelTemplateString={income_percentile_label_template_string}
             adjustedPPPConversionFactor={pppConversion?.adjustedPPPfactor}
+            periodAdjustment={periodAdjustment}
           />
         </div>
         <div

--- a/components/main/blocks/WealthCalculator/WealthCalculatorSlider.tsx
+++ b/components/main/blocks/WealthCalculator/WealthCalculatorSlider.tsx
@@ -1,5 +1,6 @@
 import { thousandize } from "../../../../util/formatting";
 import { EffektSlider } from "../../../shared/components/EffektSlider/EffektSlider";
+import { WealthCalculatorPeriodAdjustment } from "../../../shared/components/Graphs/Area/AreaGraph";
 import { calculateWealthPercentile } from "./_util";
 import styles from "./WealthCalculator.module.scss";
 
@@ -19,6 +20,7 @@ export const WealthCalculatorSlider: React.FC<{
   }[];
   equvivalizedIncome: number;
   adjustedPppFactor: number;
+  periodAdjustment: WealthCalculatorPeriodAdjustment;
   config: WealthCalculatorSliderConfig;
 }> = ({
   donationPercentage,
@@ -27,6 +29,7 @@ export const WealthCalculatorSlider: React.FC<{
   wealthMountainGraphData,
   equvivalizedIncome,
   adjustedPppFactor,
+  periodAdjustment,
   config,
 }) => {
   const [beforeInput, afterInput] =
@@ -41,6 +44,7 @@ export const WealthCalculatorSlider: React.FC<{
   const wealthPercentile = calculateWealthPercentile(
     wealthMountainGraphData,
     equvivalizedIncome * (1 - donationPercentage / 100),
+    periodAdjustment,
     adjustedPppFactor,
   ).toLocaleString("no-NB");
 

--- a/components/main/blocks/WealthCalculator/_util.ts
+++ b/components/main/blocks/WealthCalculator/_util.ts
@@ -1,12 +1,14 @@
+import { WealthCalculatorPeriodAdjustment } from "../../../shared/components/Graphs/Area/AreaGraph";
 import { getNorwegianTaxEstimate, getSwedishTaxEstimate } from "./_queries";
 
 export const calculateWealthPercentile = (
   data: { x: number; y: number }[],
   income: number,
+  periodAdjustment: WealthCalculatorPeriodAdjustment,
   adjustedPPPConversionFactor: number,
 ) => {
   const dataSum = data.reduce((acc, curr) => acc + curr.y, 0);
-  const dailyIncome = income / 365 / adjustedPPPConversionFactor;
+  const dailyIncome = income / periodAdjustment / adjustedPPPConversionFactor;
   const bucketsSumUpToLineInput = data
     .filter((d) => d.x <= dailyIncome)
     .reduce((acc, curr) => acc + curr.y, 0);
@@ -42,15 +44,19 @@ export const equvivalizeIncome = (
   return equvivalizedIncome;
 };
 
-export const getEstimatedPostTaxIncome = async (income: number, jurisdiction: TaxJurisdiction) => {
+export const getEstimatedPostTaxIncome = async (
+  income: number,
+  periodAdjustment: WealthCalculatorPeriodAdjustment,
+  jurisdiction: TaxJurisdiction,
+) => {
   // Round income to nearest 1000
   let tax = 0;
   switch (jurisdiction) {
     case TaxJurisdiction.SE:
-      tax = await getSwedishTaxEstimate(income);
+      tax = await getSwedishTaxEstimate(income, periodAdjustment);
       break;
     case TaxJurisdiction.NO:
-      tax = await getNorwegianTaxEstimate(income);
+      tax = await getNorwegianTaxEstimate(income, periodAdjustment);
       break;
     default:
       return income;

--- a/components/main/blocks/WealthCalculatorTeaser/WealthCalculatorTeaser.tsx
+++ b/components/main/blocks/WealthCalculatorTeaser/WealthCalculatorTeaser.tsx
@@ -1,7 +1,10 @@
 import styles from "./WealthCalculatorTeaser.module.scss";
 
 import { EffektButton } from "../../../shared/components/EffektButton/EffektButton";
-import { AreaChart } from "../../../shared/components/Graphs/Area/AreaGraph";
+import {
+  AreaChart,
+  WealthCalculatorPeriodAdjustment,
+} from "../../../shared/components/Graphs/Area/AreaGraph";
 import { wealthMountainGraphData } from "../WealthCalculator/data";
 import { PortableText } from "@portabletext/react";
 import { useEffect, useRef, useState } from "react";
@@ -23,6 +26,7 @@ export const WealthCalculatorTeaser: React.FC<{
   medianIncome: number;
   incomePercentileLabelTemplateString: string;
   afterDonationPercentileLabelTemplateString: string;
+  periodAdjustment: WealthCalculatorPeriodAdjustment;
   xAxisLabel: string;
   locale: string;
 }> = ({
@@ -32,6 +36,7 @@ export const WealthCalculatorTeaser: React.FC<{
   medianIncome,
   incomePercentileLabelTemplateString,
   afterDonationPercentileLabelTemplateString,
+  periodAdjustment,
   xAxisLabel,
   locale,
 }) => {
@@ -98,16 +103,19 @@ export const WealthCalculatorTeaser: React.FC<{
             wealthPercentile={calculateWealthPercentile(
               wealthMountainGraphData,
               medianIncome,
+              periodAdjustment,
               pppConversion.adjustedPPPfactor,
             )}
             afterDonationWealthPercentile={calculateWealthPercentile(
               wealthMountainGraphData,
               medianIncome * 0.9,
+              periodAdjustment,
               pppConversion.adjustedPPPfactor,
             )}
             incomePercentileLabelTemplateString={incomePercentileLabelTemplateString}
             afterDonationPercentileLabelTemplateString={afterDonationPercentileLabelTemplateString}
             adjustedPPPConversionFactor={pppConversion.adjustedPPPfactor}
+            periodAdjustment={periodAdjustment}
           />
         </div>
       </div>

--- a/cypress/e2e/wealthcalculator.js
+++ b/cypress/e2e/wealthcalculator.js
@@ -49,7 +49,7 @@ describe("Navigation", () => {
     );
     cy.get("[data-cy=wealthcalculator-graph]").should(
       "contain.text",
-      "Du er i dag blant deϥϬϤϭ rikeste i verden.",
+      "Du er i dag blant de ϥϬϤϭrikeste i verden.",
     );
   });
 
@@ -88,7 +88,7 @@ describe("Navigation", () => {
     );
     cy.get("[data-cy=wealthcalculator-graph]").should(
       "contain.text",
-      "Du er i dag blant deϥϬϤϭ rikeste i verden.",
+      "Du er i dag blant de ϥϬϤϭrikeste i verden.",
     );
   });
 
@@ -105,7 +105,7 @@ describe("Navigation", () => {
     );
     cy.get("[data-cy=wealthcalculator-graph]").should(
       "contain.text",
-      "Du er i dag blant deϥϬϤϭ rikeste i verden.",
+      "Du er i dag blant de ϥϬϤϭrikeste i verden.",
     );
     cy.get("[data-cy=wealthcalculator-donation-percentage-input]").should("have.value", "25");
   });
@@ -121,7 +121,7 @@ describe("Navigation", () => {
     );
     cy.get("[data-cy=wealthcalculator-graph]").should(
       "contain.text",
-      "Du er i dag blant deϥϬϤϭ rikeste i verden.",
+      "Du er i dag blant de ϥϬϤϭrikeste i verden.",
     );
     cy.get("[data-cy=wealthcalculator-donation-percentage-input]").should("have.value", "39");
   });

--- a/studio/schemas/types/wealthcalculatorconfiguration.ts
+++ b/studio/schemas/types/wealthcalculatorconfiguration.ts
@@ -15,6 +15,14 @@ export default {
           validation: (Rule: any) => Rule.required(),
         },
         {
+          name: "period",
+          type: "string",
+          title: "Period type",
+          options: {
+            list: ["monthly", "yearly"],
+          },
+        },
+        {
           name: "income_input_configuration",
           type: "object",
           title: "Income Input Configuration",

--- a/studio/schemas/types/wealthcalculatorteaser.ts
+++ b/studio/schemas/types/wealthcalculatorteaser.ts
@@ -30,6 +30,14 @@ export default {
       title: "Button",
     },
     {
+      name: "period",
+      type: "string",
+      title: "Period type",
+      options: {
+        list: ["monthly", "yearly"],
+      },
+    },
+    {
       name: "x_axis_label",
       type: "string",
       title: "X Axis Label",


### PR DESCRIPTION
Adds the ability to use monthly incomes in the wealth calculator

- closes #945 

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
