### PR TITLE
Adds padding to org list for better look if headers and subtitles

### DIFF
--- a/components/main/blocks/OrganizationsList/OrganizationsList.module.scss
+++ b/components/main/blocks/OrganizationsList/OrganizationsList.module.scss
@@ -24,6 +24,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  padding-right: 50px;
 }
 
 .intervention {


### PR DESCRIPTION
I added 50px padding to the left column of the org list to give the titles and subtitles a better look when they are longer



---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
