### PR TITLE
Widget outputs

### DIFF
--- a/components/profile/shared/DistributionCauseAreaInput/Distribution.tsx
+++ b/components/profile/shared/DistributionCauseAreaInput/Distribution.tsx
@@ -32,7 +32,7 @@ export const DistributionController: React.FC<{
       <div className={style.grid}>
         {currentCauseAreaOrgs.map((org) => (
           <div key={org.id} className={style["share-wrapper"]}>
-            <span>{org.name}</span>
+            <span>{org.widgetDisplayName}</span>
             <div>
               <input
                 type="text"

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -31,7 +31,6 @@ import { DonorPane } from "./panes/DonorPane/DonorPane";
 import { PaymentPane } from "./panes/PaymentPane/PaymentPane";
 import { ProgressBar } from "./shared/ProgressBar/ProgressBar";
 import { token } from "../../../../../token";
-import { StyleSheetManager } from "styled-components";
 import { useRouter } from "next/router";
 import { PrefilledDistribution } from "../../../../main/layout/WidgetPane/WidgetPane";
 import { TooltipWrapper } from "./shared/ProgressBar/ProgressBar.style";

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -34,6 +34,7 @@ import { token } from "../../../../../token";
 import { StyleSheetManager } from "styled-components";
 import { useRouter } from "next/router";
 import { PrefilledDistribution } from "../../../../main/layout/WidgetPane/WidgetPane";
+import { TooltipWrapper } from "./shared/ProgressBar/ProgressBar.style";
 
 const widgetQuery = groq`
 *[_type == "donationwidget"][0] {
@@ -227,6 +228,7 @@ export const Widget = withStaticProps(async ({ draftMode }: { draftMode: boolean
   );
 
   const { scaledHeight, scalingFactor } = useWidgetScaleEffect(widgetRef);
+  const { scrollPosition } = useWidgetScrollObserver(widgetRef);
 
   useEffect(() => {
     dispatch(fetchCauseAreasAction.started(undefined));
@@ -332,6 +334,7 @@ export const Widget = withStaticProps(async ({ draftMode }: { draftMode: boolean
       }}
     >
       <WidgetTooltipContext.Provider value={[tooltip, setTooltip]}>
+        {tooltip !== null && <TooltipWrapper top={20 + scrollPosition}>{tooltip}</TooltipWrapper>}
         <ProgressBar />
         <Carousel minHeight={scaledHeight - 116}>
           <DonationPane
@@ -377,3 +380,34 @@ export const Widget = withStaticProps(async ({ draftMode }: { draftMode: boolean
     </div>
   );
 });
+
+export const useWidgetScrollObserver = (elementRef: any) => {
+  const [scrollPosition, setScrollPosition] = useState(0);
+  const observers = useRef(new Set());
+
+  const handleScroll = useCallback((event: any) => {
+    const newPosition = event.target.scrollTop;
+    setScrollPosition(newPosition);
+    observers.current.forEach((observer: any) => observer(newPosition));
+  }, []);
+
+  useEffect(() => {
+    const element = elementRef.current;
+    if (element) {
+      element.addEventListener("scroll", handleScroll);
+    }
+
+    return () => {
+      if (element) {
+        element.removeEventListener("scroll", handleScroll);
+      }
+    };
+  }, [elementRef, handleScroll]);
+
+  const subscribe = useCallback((observer: any) => {
+    observers.current.add(observer);
+    return () => observers.current.delete(observer);
+  }, []);
+
+  return { scrollPosition, subscribe };
+};

--- a/components/shared/components/Widget/components/panes/DonationPane/ShareSelector/ShareSelection.tsx
+++ b/components/shared/components/Widget/components/panes/DonationPane/ShareSelector/ShareSelection.tsx
@@ -59,7 +59,7 @@ export const SharesSelection: React.FC<{
           return (
             <ShareInputContainer key={org.id}>
               <div>
-                <ShareLink href={organization.informationUrl}>
+                <ShareLink href={organization.informationUrl} target="_blank">
                   <label htmlFor={org.id.toString()}>{organization.widgetDisplayName}</label>
                 </ShareLink>
                 {organization.widgetContext && <ToolTip text={organization.widgetContext} />}

--- a/components/shared/components/Widget/components/panes/DonationPane/ShareSelector/ShareSelection.tsx
+++ b/components/shared/components/Widget/components/panes/DonationPane/ShareSelector/ShareSelection.tsx
@@ -12,6 +12,7 @@ import {
 import AnimateHeight from "react-animate-height";
 import { CauseArea } from "../../../../types/CauseArea";
 import { ErrorText } from "../DonationPane";
+import { ToolTip } from "../../../shared/ToolTip/ToolTip";
 
 export const SharesSelection: React.FC<{
   causeArea: CauseArea;
@@ -52,39 +53,42 @@ export const SharesSelection: React.FC<{
   return (
     <ShareSelectionWrapper data-error={relevantErrorTexts[0]?.error.type}>
       <ShareContainer ref={wrapperRef}>
-        {distributionCauseArea.organizations.map((org) => (
-          <ShareInputContainer key={org.id}>
-            <div>
-              <ShareLink href={org.informationUrl}>
-                <label htmlFor={org.id.toString()}>
-                  {organizations.filter((o) => o.id === org.id)[0].name}
-                </label>
-              </ShareLink>
-            </div>
-            <input
-              data-cy={`org-${org.id}`}
-              type="tel"
-              name={org.id.toString()}
-              placeholder="0"
-              value={org.percentageShare}
-              onChange={(e) => {
-                const newOrganizationShares = [...distributionCauseArea.organizations];
-                const index = newOrganizationShares.map((s) => s.id).indexOf(org.id);
+        {distributionCauseArea.organizations.map((org) => {
+          const organization = organizations.find((o) => o.id === org.id);
+          if (!organization) return null;
+          return (
+            <ShareInputContainer key={org.id}>
+              <div>
+                <ShareLink href={organization.informationUrl}>
+                  <label htmlFor={org.id.toString()}>{organization.widgetDisplayName}</label>
+                </ShareLink>
+                {organization.widgetContext && <ToolTip text={organization.widgetContext} />}
+              </div>
+              <input
+                data-cy={`org-${org.id}`}
+                type="tel"
+                name={org.id.toString()}
+                placeholder="0"
+                value={org.percentageShare}
+                onChange={(e) => {
+                  const newOrganizationShares = [...distributionCauseArea.organizations];
+                  const index = newOrganizationShares.map((s) => s.id).indexOf(org.id);
 
-                if (e.target.value === "") {
-                  newOrganizationShares[index].percentageShare = "0";
-                } else if (Number.isInteger(parseInt(e.target.value))) {
-                  const newSplit = parseInt(e.target.value);
-                  if (newSplit <= 100 && newSplit >= 0) {
-                    newOrganizationShares[index].percentageShare = newSplit.toString();
+                  if (e.target.value === "") {
+                    newOrganizationShares[index].percentageShare = "0";
+                  } else if (Number.isInteger(parseInt(e.target.value))) {
+                    const newSplit = parseInt(e.target.value);
+                    if (newSplit <= 100 && newSplit >= 0) {
+                      newOrganizationShares[index].percentageShare = newSplit.toString();
+                    }
                   }
-                }
 
-                dispatch(setShares(distributionCauseArea.id, newOrganizationShares));
-              }}
-            />
-          </ShareInputContainer>
-        ))}
+                  dispatch(setShares(distributionCauseArea.id, newOrganizationShares));
+                }}
+              />
+            </ShareInputContainer>
+          );
+        })}
       </ShareContainer>
       <AnimateHeight height={hasError ? "auto" : 0} duration={300} animateOpacity>
         <ErrorContainer>

--- a/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
+++ b/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
@@ -142,8 +142,8 @@ export const DonorPane: React.FC<{
                   })}
                 />
                 <CustomCheckBox label={text.anon_button_text} checked={isAnonymous} />
+                <ToolTip text={text.anon_button_text_tooltip} />
               </CheckBoxWrapper>
-              <ToolTip text={text.anon_button_text_tooltip} />
             </div>
 
             {!isAnonymous ? (
@@ -195,8 +195,9 @@ export const DonorPane: React.FC<{
                         label={text.tax_deduction_selector_text}
                         checked={taxDeductionChecked}
                       />
+                      {taxDeductionChecked && <ToolTip text={text.tax_deduction_tooltip_text} />}
                     </CheckBoxWrapper>
-                    {taxDeductionChecked && <ToolTip text={text.tax_deduction_tooltip_text} />}
+
                     {taxDeductionChecked && (
                       <InputFieldWrapper>
                         <input

--- a/components/shared/components/Widget/components/shared/ProgressBar/ProgressBar.style.tsx
+++ b/components/shared/components/Widget/components/shared/ProgressBar/ProgressBar.style.tsx
@@ -79,16 +79,19 @@ export const ActionButton = styled.button.withConfig({
   }
 `;
 
-export const TooltipWrapper = styled.div`
+export const TooltipWrapper = styled.div<{
+  top: number;
+}>`
   position: absolute;
-  top: 20px;
-  left: 20px;
+  top: ${(props) => Math.round(props.top)}px;
+  margin-left: 20px;
+  margin-right: 20px;
   right: 20px;
   background: var(--primary);
   color: var(--secondary);
   padding: 40px;
-  z-index: 100;
   font-size: 18px;
   border-radius: 10px;
   pointer-events: none;
+  z-index: 100;
 `;

--- a/components/shared/components/Widget/components/shared/ProgressBar/ProgressBar.tsx
+++ b/components/shared/components/Widget/components/shared/ProgressBar/ProgressBar.tsx
@@ -3,14 +3,12 @@ import { useDispatch, useSelector } from "react-redux";
 import { WidgetContext } from "../../../../../../main/layout/layout";
 import { prevPane } from "../../../store/layout/actions";
 import { State } from "../../../store/state";
-import { WidgetTooltipContext } from "../../Widget";
 import {
   ProgressContainer,
   ProgressCircle,
   ProgressLine,
   HeaderContainer,
   ActionButton,
-  TooltipWrapper,
 } from "./ProgressBar.style";
 
 export const ProgressBar: React.FC = () => {
@@ -18,7 +16,6 @@ export const ProgressBar: React.FC = () => {
   const dispatch = useDispatch();
   const paneNumber = useSelector((state: State) => state.layout.paneNumber);
   const [widgetContext, setWidgetContext] = useContext(WidgetContext);
-  const [tooltip, setTooltip] = useContext(WidgetTooltipContext);
 
   const points = [];
   for (let i = 0; i < numberOfPanes; i++) {
@@ -27,7 +24,6 @@ export const ProgressBar: React.FC = () => {
 
   return (
     <HeaderContainer>
-      {tooltip !== null && <TooltipWrapper>{tooltip}</TooltipWrapper>}
       <ActionButton
         data-cy="back-button"
         disabled={paneNumber === 0}

--- a/components/shared/components/Widget/components/shared/ToolTip/ToolTip.tsx
+++ b/components/shared/components/Widget/components/shared/ToolTip/ToolTip.tsx
@@ -4,11 +4,9 @@ import { WidgetTooltipContext } from "../../Widget";
 import { ToolTipIcon } from "./ToolTipIcon";
 
 const ToolTipWrapper = styled.div`
-  vertical-align: middle;
   display: inline-flex;
   align-items: center;
   vertical-align: middle;
-  margin-bottom: 12px;
 `;
 
 export const ToolTip: React.FC<{ text: string }> = ({ text }) => {

--- a/components/shared/components/Widget/components/shared/ToolTip/ToolTipIcon.tsx
+++ b/components/shared/components/Widget/components/shared/ToolTip/ToolTipIcon.tsx
@@ -9,8 +9,7 @@ const TooltipIconButton = styled.button.attrs({
   pointer-events: all;
   background: transparent;
   height: 100%;
-  vertical-align: center;
-  margin-left: 10px;
+  vertical-align: middle;
   padding: 0 10px;
 
   &:hover {
@@ -25,13 +24,14 @@ const TooltipIconButton = styled.button.attrs({
 
 const TooltipInnerIcon = styled.div`
   border: 1px solid var(--primary);
-  width: 34px;
-  height: 34px;
+  width: 2em;
+  height: 2em;
   display: inline-flex;
   justify-content: center;
   align-items: center;
   border-radius: 50%;
-  font-size: 20px;
+  font-size: 0.8em;
+  vertical-align: middle;
 `;
 
 interface ToolIconProps {

--- a/components/shared/components/Widget/types/Organization.ts
+++ b/components/shared/components/Widget/types/Organization.ts
@@ -7,6 +7,8 @@ export interface Organization {
   standardShare?: number;
   /** @description The organization name */
   name: string;
+  widgetDisplayName?: string;
+  widgetContext?: string;
   /** @description The organization abbreviation */
   abbreviation?: string;
   /** @description The organization short description */


### PR DESCRIPTION
Allows for a separate widget name for organizations, allowing to show outputs rather than organization names. Also allows for a tooltip by organizations, and fixes links to organization pages.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
