### PR TITLE
Add donation widget block to schema

### DIFF
--- a/_queries.ts
+++ b/_queries.ts
@@ -4,6 +4,7 @@ import { apiResult, getAccessTokenSilently } from "./hooks/useApi";
 import { TaxUnit } from "./models";
 import { getUserId } from "./lib/user";
 import { CauseArea } from "./components/shared/components/Widget/types/CauseArea";
+import { widgetContentQuery } from "./components/shared/components/Widget/components/Widget";
 
 export interface Query<T> {
   (
@@ -647,7 +648,9 @@ export const pageContentQuery = `content[hidden!=true] {
     },
     _type == 'donationwidgetblock' => {
       ...,
-      donationwidget->,
+      donationwidget->{
+        ${widgetContentQuery}
+      }
     },
     _type != 'splitviewhtml' && _type != 'teamintroduction' && _type!= 'fullimage' && _type != 'normalimage' && _type != 'teasers' && _type != 'giveblock' && _type != 'links' && _type != 'questionandanswergroup' && _type != 'reference' && _type != 'testimonials' && _type != 'organizationslist' && _type != 'opendistributionbutton' && _type != 'fullvideo' && _type!= 'paragraph' && _type != 'splitview' && _type != 'contributorlist' && _type != 'inngress' && _type != 'wealthcalculator' && _type != 'giftcardteaser' && _type != 'columns' && _type != 'interventionwidget' && _type != 'wealthcalculatorteaser' && _type != 'accordion' && _type != 'plausiblerevenuetracker' && _type != 'philantropicteaser' && _type != 'fundraiserchart' => @ && _type != 'donationwidgetblock',
   }

--- a/_queries.ts
+++ b/_queries.ts
@@ -645,7 +645,11 @@ export const pageContentQuery = `content[hidden!=true] {
       ...,
       "locale": *[ _type == "site_settings"][0].main_locale,
     },
-    _type != 'splitviewhtml' && _type != 'teamintroduction' && _type!= 'fullimage' && _type != 'normalimage' && _type != 'teasers' && _type != 'giveblock' && _type != 'links' && _type != 'questionandanswergroup' && _type != 'reference' && _type != 'testimonials' && _type != 'organizationslist' && _type != 'opendistributionbutton' && _type != 'fullvideo' && _type!= 'paragraph' && _type != 'splitview' && _type != 'contributorlist' && _type != 'inngress' && _type != 'wealthcalculator' && _type != 'giftcardteaser' && _type != 'columns' && _type != 'interventionwidget' && _type != 'wealthcalculatorteaser' && _type != 'accordion' && _type != 'plausiblerevenuetracker' && _type != 'philantropicteaser' && _type != 'fundraiserchart' => @,
+    _type == 'donationwidgetblock' => {
+      ...,
+      donationwidget->,
+    },
+    _type != 'splitviewhtml' && _type != 'teamintroduction' && _type!= 'fullimage' && _type != 'normalimage' && _type != 'teasers' && _type != 'giveblock' && _type != 'links' && _type != 'questionandanswergroup' && _type != 'reference' && _type != 'testimonials' && _type != 'organizationslist' && _type != 'opendistributionbutton' && _type != 'fullvideo' && _type!= 'paragraph' && _type != 'splitview' && _type != 'contributorlist' && _type != 'inngress' && _type != 'wealthcalculator' && _type != 'giftcardteaser' && _type != 'columns' && _type != 'interventionwidget' && _type != 'wealthcalculatorteaser' && _type != 'accordion' && _type != 'plausiblerevenuetracker' && _type != 'philantropicteaser' && _type != 'fundraiserchart' => @ && _type != 'donationwidgetblock',
   }
 },
 `;

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -43,6 +43,7 @@ import { TeamIntroduction } from "./TeamIntroduction/TeamIntroduction";
 import { ResultsTeaser } from "./ResultsTeaser/ResultsTeaser";
 import { TaxDeductionWidget } from "./TaxDeductionWidget/TaxDeductionWidget";
 import { Widget } from "../../shared/components/Widget/components/Widget";
+import { WidgetWithStore } from "../../shared/components/Widget/components/WidgetWithStore";
 
 /* Dynamic imports */
 const WealthCalculator = dynamic(() =>
@@ -443,7 +444,7 @@ export const SectionBlockContentRenderer: React.FC<{ blocks: any }> = ({ blocks 
             );
           case "donationwidgetblock":
             return (
-              <Widget
+              <WidgetWithStore
                 key={block._key || block._id}
                 inline={true}
                 {...{

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -42,6 +42,7 @@ import { FundraiserChart } from "./FundraiserChart/FundraiserChart";
 import { TeamIntroduction } from "./TeamIntroduction/TeamIntroduction";
 import { ResultsTeaser } from "./ResultsTeaser/ResultsTeaser";
 import { TaxDeductionWidget } from "./TaxDeductionWidget/TaxDeductionWidget";
+import { Widget } from "../../shared/components/Widget/components/Widget";
 
 /* Dynamic imports */
 const WealthCalculator = dynamic(() =>
@@ -440,6 +441,8 @@ export const SectionBlockContentRenderer: React.FC<{ blocks: any }> = ({ blocks 
                 locale={block.locale}
               />
             );
+          case "donation_widget_block":
+            return <Widget key={block._key || block._id} inline={true} />;
           default:
             return block._type;
         }

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -441,8 +441,19 @@ export const SectionBlockContentRenderer: React.FC<{ blocks: any }> = ({ blocks 
                 locale={block.locale}
               />
             );
-          case "donation_widget_block":
-            return <Widget key={block._key || block._id} inline={true} />;
+          case "donationwidgetblock":
+            return (
+              <Widget
+                key={block._key || block._id}
+                inline={true}
+                {...{
+                  data: {
+                    result: block.donationwidget,
+                    query: "",
+                  },
+                }}
+              />
+            );
           default:
             return block._type;
         }

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -44,6 +44,8 @@ import { ResultsTeaser } from "./ResultsTeaser/ResultsTeaser";
 import { TaxDeductionWidget } from "./TaxDeductionWidget/TaxDeductionWidget";
 import { Widget } from "../../shared/components/Widget/components/Widget";
 import { WidgetWithStore } from "../../shared/components/Widget/components/WidgetWithStore";
+import { PrefilledDistribution } from "../layout/WidgetPane/WidgetPane";
+import { DonationWidgetBlock } from "./DonationWidgetBlock/DonationWidgetBlock";
 
 /* Dynamic imports */
 const WealthCalculator = dynamic(() =>
@@ -444,15 +446,13 @@ export const SectionBlockContentRenderer: React.FC<{ blocks: any }> = ({ blocks 
             );
           case "donationwidgetblock":
             return (
-              <WidgetWithStore
+              <DonationWidgetBlock
                 key={block._key || block._id}
-                inline={true}
-                {...{
-                  data: {
-                    result: block.donationwidget,
-                    query: "",
-                  },
-                }}
+                widgetConfiguration={block.donationwidget}
+                overrides={block.overrides}
+                content={block.content}
+                contentPosition={block.content_position}
+                contentMobilePosition={block.content_mobile_position}
               />
             );
           default:

--- a/components/main/blocks/DonationWidgetBlock/DonationWidgetBlock.module.scss
+++ b/components/main/blocks/DonationWidgetBlock/DonationWidgetBlock.module.scss
@@ -1,0 +1,28 @@
+.wrapper {
+  display: flex;
+  align-items: flex-start;
+  flex-direction: row;
+  gap: 5rem;
+  width: 100%;
+  justify-content: center;
+
+  .widget {
+    border: 1px solid var(--primary);
+    border-radius: 1rem;
+  }
+}
+
+@media only screen and (max-width: 1180px) {
+  .wrapper {
+    flex-direction: column;
+    gap: 2rem;
+
+    .widget {
+      transform: translateX(-5vw);
+      border: none;
+      border-top: 1px solid var(--primary);
+      border-bottom: 1px solid var(--primary);
+      border-radius: 0;
+    }
+  }
+}

--- a/components/main/blocks/DonationWidgetBlock/DonationWidgetBlock.tsx
+++ b/components/main/blocks/DonationWidgetBlock/DonationWidgetBlock.tsx
@@ -1,4 +1,5 @@
 import { WidgetWithStore } from "../../../shared/components/Widget/components/WidgetWithStore";
+import { RecurringDonation } from "../../../shared/components/Widget/types/Enums";
 import { WidgetProps } from "../../../shared/components/Widget/types/WidgetProps";
 import { PrefilledDistribution, WidgetPaneProps } from "../../layout/WidgetPane/WidgetPane";
 import { Paragraph } from "../Paragraph/Paragraph";
@@ -11,6 +12,16 @@ export const DonationWidgetBlock: React.FC<{
   contentPosition: "left" | "right";
   contentMobilePosition: "top" | "bottom";
 }> = ({ widgetConfiguration, overrides, content, contentPosition, contentMobilePosition }) => {
+  let defaultPaymentType = RecurringDonation.NON_RECURRING;
+  if (overrides?.default_donation_type) {
+    if (overrides.default_donation_type === "recurring") {
+      defaultPaymentType = RecurringDonation.RECURRING;
+    }
+    if (overrides.default_donation_type === "single") {
+      defaultPaymentType = RecurringDonation.NON_RECURRING;
+    }
+  }
+
   return (
     <div className={styles.wrapper}>
       <div className={styles.widget}>
@@ -24,6 +35,7 @@ export const DonationWidgetBlock: React.FC<{
           }}
           prefilled={convertToPrefilledDistribution(overrides?.prefilled_distribution)}
           prefilledSum={overrides?.prefilled_sum ?? null}
+          defaultPaymentType={defaultPaymentType}
         />
       </div>
       {content && content.length > 0 && (

--- a/components/main/blocks/DonationWidgetBlock/DonationWidgetBlock.tsx
+++ b/components/main/blocks/DonationWidgetBlock/DonationWidgetBlock.tsx
@@ -1,0 +1,77 @@
+import { WidgetWithStore } from "../../../shared/components/Widget/components/WidgetWithStore";
+import { WidgetProps } from "../../../shared/components/Widget/types/WidgetProps";
+import { PrefilledDistribution, WidgetPaneProps } from "../../layout/WidgetPane/WidgetPane";
+import { Paragraph } from "../Paragraph/Paragraph";
+import styles from "./DonationWidgetBlock.module.scss";
+
+export const DonationWidgetBlock: React.FC<{
+  widgetConfiguration: WidgetProps;
+  overrides?: any;
+  content?: any[];
+  contentPosition: "left" | "right";
+  contentMobilePosition: "top" | "bottom";
+}> = ({ widgetConfiguration, overrides, content, contentPosition, contentMobilePosition }) => {
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.widget}>
+        <WidgetWithStore
+          inline={true}
+          {...{
+            data: {
+              result: widgetConfiguration,
+              query: "",
+            },
+          }}
+          prefilled={convertToPrefilledDistribution(overrides?.prefilled_distribution)}
+          prefilledSum={overrides?.prefilled_sum ?? null}
+        />
+      </div>
+      {content && content.length > 0 && (
+        <Paragraph title={""} tocKey="" blocks={content}></Paragraph>
+      )}
+    </div>
+  );
+};
+
+// Input type
+type InputDistribution = {
+  _key: string;
+  id: number;
+  causeAreaId?: number;
+  name: string;
+  percentage: number;
+  type: "causeArea" | "organization";
+}[];
+
+/**
+ * Converts from the input format to PrefilledDistribution
+ * @param input The input distribution array
+ * @returns The converted PrefilledDistribution
+ */
+function convertToPrefilledDistribution(input?: InputDistribution): PrefilledDistribution | null {
+  if (!input) return null;
+  if (input.length === 0) return null;
+
+  const result: PrefilledDistribution = [];
+
+  // Separate cause areas and organizations
+  const causeAreas = input.filter((item) => item.type === "causeArea");
+  const organizations = input.filter((item) => item.type === "organization");
+
+  // Create each cause area entry in the result
+  causeAreas.forEach((causeArea) => {
+    const causeAreaId = causeArea.id;
+    const relatedOrgs = organizations.filter((org) => org.causeAreaId === causeAreaId);
+
+    result.push({
+      causeAreaId: causeAreaId,
+      share: causeArea.percentage,
+      organizations: relatedOrgs.map((org) => ({
+        organizationId: org.id,
+        share: org.percentage,
+      })),
+    });
+  });
+
+  return result;
+}

--- a/components/shared/components/RadioButton/RadioButton.tsx
+++ b/components/shared/components/RadioButton/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useId } from "react";
 import styles from "./RadioButtons.module.scss";
 
 export const RadioButton: React.FC<{
@@ -9,12 +9,15 @@ export const RadioButton: React.FC<{
   data_cy: string;
   onSelect: () => void;
 }> = ({ selected, name, title, disabled, data_cy, onSelect }) => {
+  const uniqueId = useId();
+  const uniqueName = `${name}-${uniqueId}`;
+
   return (
     <label className={styles.radiobuttonwrapper}>
       <input
         data-cy={data_cy}
         type={"radio"}
-        name={name}
+        name={uniqueName}
         title={title}
         className={styles.radiobutton}
         checked={selected}

--- a/components/shared/components/Widget/components/Carousel.tsx
+++ b/components/shared/components/Widget/components/Carousel.tsx
@@ -2,16 +2,43 @@ import React, { useRef, useState, useEffect, ReactNode } from "react";
 import { useSelector } from "react-redux";
 
 import { State } from "../store/state";
+import AnimateHeight from "react-animate-height";
 
 interface ICarouselProps {
   children: React.ReactNode[];
   minHeight: number;
+  inline?: boolean;
 }
 
-export const Carousel: React.FC<ICarouselProps> = ({ children, minHeight }) => {
+function smoothScrollTo(element: any, to: number, duration: number) {
+  const start = element.scrollTop;
+  const change = to - start;
+  const startTime = performance.now();
+
+  function animate(currentTime: number) {
+    const elapsed = currentTime - startTime;
+    const progress = Math.min(elapsed / duration, 1);
+
+    // Easing function (ease-in-out)
+    const easeProgress =
+      progress < 0.5 ? 2 * progress * progress : 1 - Math.pow(-2 * progress + 2, 2) / 2;
+
+    element.scrollTop = start + change * easeProgress;
+
+    if (progress < 1) {
+      requestAnimationFrame(animate);
+    }
+  }
+
+  requestAnimationFrame(animate);
+}
+
+export const Carousel: React.FC<ICarouselProps> = ({ children, minHeight, inline }) => {
+  const carouselRef = useRef<HTMLDivElement>(null);
   const [currentPaneNumber, setCurrentPaneNumber] = useState(0); // get from redux global state
   const reduxPaneNumber = useSelector((state: State) => state.layout.paneNumber);
   const [renderedPanes, setRenderedPanes] = useState([1]);
+  const [temporaryHeight, setTemporaryHeight] = useState<number | null>(null);
   const renderedPanesRef = useRef(renderedPanes);
   renderedPanesRef.current = renderedPanes;
   const currentPaneNumberRef = useRef(currentPaneNumber);
@@ -21,13 +48,30 @@ export const Carousel: React.FC<ICarouselProps> = ({ children, minHeight }) => {
     const newRenderedPanes = [...renderedPanes];
     newRenderedPanes[currentPaneNumber + offset] = 1;
     setRenderedPanes(newRenderedPanes);
-
     setCurrentPaneNumber(currentPaneNumber + offset);
+
+    // Smooth scroll carousel wrapper to top
+    if (carouselRef.current?.parentElement) {
+      if (inline) {
+        window.scrollTo({
+          top: carouselRef.current.parentElement.offsetTop,
+          behavior: "smooth",
+        });
+      } else {
+        smoothScrollTo(carouselRef.current.parentElement, 0, 200);
+      }
+    }
+
+    setTimeout(() => {
+      const currentHeight = carouselRef.current?.clientHeight;
+      setTemporaryHeight(currentHeight || null);
+    }, 1);
 
     setTimeout(() => {
       const newRenderedPanes2 = [...renderedPanesRef.current];
       newRenderedPanes2[currentPaneNumberRef.current - offset] = 0;
       setRenderedPanes(newRenderedPanes2);
+      setTemporaryHeight(null);
     }, 200);
   };
 
@@ -41,24 +85,26 @@ export const Carousel: React.FC<ICarouselProps> = ({ children, minHeight }) => {
   }, [reduxPaneNumber]);
 
   return (
-    <div id="carousel-wrapper" style={{ minHeight: `${minHeight}px` }}>
-      <div
-        id="carousel"
-        style={{
-          transform: `translate3d(${currentPaneNumber * -100}%, 0px, 0px)`,
-        }}
-      >
-        {children &&
-          children
-            .filter((child: ReactNode) => child !== false)
-            .map((child: ReactNode, i: number) => {
-              return (
-                <div className="pane" key={i}>
-                  {renderedPanes[i] === 1 && child}
-                </div>
-              );
-            })}
-      </div>
+    <div className="carousel-wrapper" style={{ minHeight: `${minHeight}px` }} ref={carouselRef}>
+      <AnimateHeight height={temporaryHeight ? temporaryHeight : "auto"} duration={200}>
+        <div
+          className="carousel"
+          style={{
+            transform: `translate3d(${currentPaneNumber * -100}%, 0px, 0px)`,
+          }}
+        >
+          {children &&
+            children
+              .filter((child: ReactNode) => child !== false)
+              .map((child: ReactNode, i: number) => {
+                return (
+                  <div className="pane" key={i}>
+                    {renderedPanes[i] === 1 && child}
+                  </div>
+                );
+              })}
+        </div>
+      </AnimateHeight>
     </div>
   );
 };

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -181,7 +181,15 @@ const useWidgetScaleEffect = (widgetRef: React.RefObject<HTMLDivElement>, inline
       setLastWidth(window.innerWidth);
       setLastHeight(window.innerHeight);
     }
-  }, [setScalingFactor, setScaledHeight, scalingFactor, scaledHeight, setLastWidth, setLastHeight, inline]);
+  }, [
+    setScalingFactor,
+    setScaledHeight,
+    scalingFactor,
+    scaledHeight,
+    setLastWidth,
+    setLastHeight,
+    inline,
+  ]);
 
   useEffect(() => scaleWidget, [widgetContext.open, scaleWidget]);
 
@@ -204,20 +212,23 @@ const useWidgetScaleEffect = (widgetRef: React.RefObject<HTMLDivElement>, inline
   return useMemo(() => ({ scaledHeight, scalingFactor }), [scaledHeight, scalingFactor]);
 };
 
-export const Widget = withStaticProps(async ({ draftMode }: { draftMode: boolean }) => {
-  const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
+export const Widget = withStaticProps(
+  async ({ draftMode, inline }: { draftMode: boolean; inline?: boolean }) => {
+    const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
 
-  if (!result.methods?.length) {
-    throw new Error("No payment methods found");
-  }
+    if (!result.methods?.length) {
+      throw new Error("No payment methods found");
+    }
 
-  return {
-    data: {
-      result,
-      query: widgetQuery,
-    },
-  };
-})(({ data, inline = false }) => {
+    return {
+      data: {
+        result,
+        query: widgetQuery,
+      },
+      inline: inline ?? false,
+    };
+  },
+)(({ data, inline = false }) => {
   const widget = data.result;
   const methods = data.result.methods;
 

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -280,16 +280,14 @@ export const Widget = withStaticProps(
       tooltipReadmoreText = "Read more";
   }
 
-  console.log("RENDER");
-
   return (
     <div
-      id="widget"
+      className="widget"
       ref={widgetRef}
       style={{
         transform: `scale(${scalingFactor})`,
-        height: `${scaledHeight}px`,
-        flexBasis: `${scaledHeight}px`,
+        height: inline ? "auto" : `${scaledHeight}px`,
+        flexBasis: inline ? "auto" : `${scaledHeight}px`,
       }}
     >
       <WidgetTooltipContext.Provider value={[tooltip, setTooltip]}>
@@ -303,8 +301,8 @@ export const Widget = withStaticProps(
             )}
           </TooltipWrapper>
         )}
-        <ProgressBar />
-        <Carousel minHeight={scaledHeight - 116}>
+        <ProgressBar inline={inline} />
+        <Carousel minHeight={inline ? 0 : scaledHeight - 116}>
           <DonationPane
             text={{
               single_donation_text: widget.single_donation_text,

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -1,24 +1,11 @@
 import { groq } from "next-sanity";
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { createContext, useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { useDebouncedCallback } from "use-debounce";
 import { getClient } from "../../../../../lib/sanity.client";
 import { withStaticProps } from "../../../../../util/withStaticProps";
-import { WidgetContext } from "../../../../main/layout/layout";
 import { fetchCauseAreasAction } from "../store/layout/actions";
-import { paymentMethodConfigurations } from "../config/methods";
-import { setRecurring } from "../store/donation/actions";
 import { fetchReferralsAction } from "../store/referrals/actions";
 import { State } from "../store/state";
-import { RecurringDonation } from "../types/Enums";
 import { WidgetProps } from "../types/WidgetProps";
 import { Carousel } from "./Carousel";
 import { DonationPane } from "./panes/DonationPane/DonationPane";
@@ -31,9 +18,18 @@ import {
   TooltipLink,
   TooltipWrapper,
 } from "./shared/ProgressBar/ProgressBar.style";
-import { usePrefilledDistribution, usePrefilledSum, useQueryParamsPrefill } from "./hooks";
+import {
+  useAvailablePaymentMethods,
+  useAvailableRecurringOptions,
+  useDefaultPaymentMethodEffect,
+  usePrefilledDistribution,
+  usePrefilledSum,
+  useQueryParamsPrefill,
+  useWidgetScaleEffect,
+} from "./hooks";
 import { useElementHeight } from "../../../../../hooks/useElementHeight";
 import { PrefilledDistribution } from "../../../../main/layout/WidgetPane/WidgetPane";
+import { RecurringDonation } from "../types/Enums";
 
 export const widgetContentQuery = groq`
 ...,
@@ -89,137 +85,17 @@ export const WidgetTooltipContext = createContext<[{ text: string; link?: string
   () => {},
 ]);
 
-/**
- * Determine available recurring options based on the configured payment methods
- */
-const useAvailableRecurringOptions = (paymentMethods: NonNullable<WidgetProps["methods"]>) => {
-  const recurring = useMemo(
-    () =>
-      paymentMethods.some((method) => {
-        const configuration = paymentMethodConfigurations.find(
-          (config) => config.id === method._id,
-        );
-        return configuration?.recurringOptions.includes(RecurringDonation.RECURRING);
-      }),
-    [paymentMethods],
-  );
-
-  const single = useMemo(
-    () =>
-      paymentMethods.some((method) => {
-        const configuration = paymentMethodConfigurations.find(
-          (config) => config.id === method._id,
-        );
-        return configuration?.recurringOptions.includes(RecurringDonation.NON_RECURRING);
-      }),
-    [paymentMethods],
-  );
-
-  return useMemo(() => ({ recurring, single }), [recurring, single]);
-};
-
-/**
- * Determine available payment methods based on the selected recurring option
- */
-const useAvailablePaymentMethods = (paymentMethods: NonNullable<WidgetProps["methods"]>) => {
-  const recurring = useSelector((state: State) => state.donation.recurring);
-
-  const availablePaymentMethods = useMemo(
-    () =>
-      paymentMethods.filter((method) => {
-        const configuration = paymentMethodConfigurations.find(
-          (config) => config.id === method._id,
-        );
-        return configuration?.recurringOptions.includes(recurring);
-      }),
-    [paymentMethods, recurring],
-  );
-
-  return availablePaymentMethods;
-};
-
-/**
- * This effect is used to set the default payment method to single if recurring is not enabled
- */
-const useDefaultPaymentMethodEffect = (paymentMethods: NonNullable<WidgetProps["methods"]>) => {
-  const dispatch = useDispatch();
-  const recurring = useSelector((state: State) => state.donation.recurring);
-
-  const availableRecurringOptions = useAvailableRecurringOptions(paymentMethods);
-
-  useEffect(() => {
-    if (recurring === RecurringDonation.RECURRING && !availableRecurringOptions.recurring) {
-      dispatch(setRecurring(RecurringDonation.NON_RECURRING));
-    }
-  }, [recurring, availableRecurringOptions.recurring, dispatch]);
-};
-
-/**
- * Scale the widget to fit the screen
- */
-const useWidgetScaleEffect = (widgetRef: React.RefObject<HTMLDivElement>, inline: boolean) => {
-  const [widgetContext, setWidgetContext] = useContext(WidgetContext);
-  const [scalingFactor, setScalingFactor] = useState(1);
-  const [scaledHeight, setScaledHeight] = useState(979);
-  const [lastHeight, setLastHeight] = useState(979);
-  const [lastWidth, setLastWidth] = useState(400);
-
-  const scaleWidget = useCallback(() => {
-    if (!inline || window.innerWidth < 1180) {
-      setScalingFactor(
-        (window.innerWidth >= 1180 ? Math.min(window.innerWidth * 0.4, 720) : window.innerWidth) /
-          576,
-      );
-      setScaledHeight(Math.ceil(window.innerHeight / scalingFactor));
-      if (window.innerHeight != lastHeight && window.innerWidth == lastWidth) {
-        // This is probably the android keyboard opening
-        const delta = lastHeight - window.innerHeight;
-        if (delta > 0) widgetRef.current?.scrollTo(0, Math.ceil(delta / scalingFactor));
-        else widgetRef.current?.scrollTo(0, 0);
-      }
-      setLastWidth(window.innerWidth);
-      setLastHeight(window.innerHeight);
-    }
-  }, [
-    setScalingFactor,
-    setScaledHeight,
-    scalingFactor,
-    scaledHeight,
-    setLastWidth,
-    setLastHeight,
-    inline,
-  ]);
-
-  useEffect(() => scaleWidget, [widgetContext.open, scaleWidget]);
-
-  const debouncedScaleWidget = useDebouncedCallback(() => scaleWidget(), 1000, { maxWait: 1000 });
-
-  useEffect(() => {
-    if (!inline) {
-      window.addEventListener("resize", debouncedScaleWidget);
-
-      return () => {
-        window.removeEventListener("resize", debouncedScaleWidget);
-      };
-    }
-  }, [debouncedScaleWidget, inline]);
-
-  useEffect(() => {
-    scaleWidget();
-  }, [widgetContext, scaleWidget]);
-
-  return useMemo(() => ({ scaledHeight, scalingFactor }), [scaledHeight, scalingFactor]);
-};
-
 export const Widget = withStaticProps(
   async ({
     draftMode,
     inline,
     prefilled,
+    defaultPaymentType,
   }: {
     draftMode: boolean;
     inline?: boolean;
     prefilled?: PrefilledDistribution;
+    defaultPaymentType?: RecurringDonation;
   }) => {
     const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
 
@@ -234,9 +110,10 @@ export const Widget = withStaticProps(
       },
       inline: inline ?? false,
       prefilled: prefilled ?? null,
+      defaultPaymentType: defaultPaymentType ?? RecurringDonation.NON_RECURRING,
     };
   },
-)(({ data, inline = false, prefilled }) => {
+)(({ data, inline = false, prefilled, defaultPaymentType }) => {
   const widget = data.result;
   const methods = data.result.methods;
 
@@ -278,6 +155,7 @@ export const Widget = withStaticProps(
   useQueryParamsPrefill({
     inline,
     causeAreas,
+    defaultPaymentType,
   });
 
   useDefaultPaymentMethodEffect(methods);

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -32,6 +32,7 @@ import {
   TooltipWrapper,
 } from "./shared/ProgressBar/ProgressBar.style";
 import { usePrefilledDistribution, usePrefilledSum, useQueryParamsPrefill } from "./hooks";
+import { useElementHeight } from "../../../../../hooks/useElementHeight";
 
 export const widgetContentQuery = groq`
 ...,
@@ -163,7 +164,7 @@ const useWidgetScaleEffect = (widgetRef: React.RefObject<HTMLDivElement>, inline
   const [lastWidth, setLastWidth] = useState(400);
 
   const scaleWidget = useCallback(() => {
-    if (!inline) {
+    if (!inline || window.innerWidth < 1180) {
       setScalingFactor(
         (window.innerWidth >= 1180 ? Math.min(window.innerWidth * 0.4, 720) : window.innerWidth) /
           576,
@@ -235,6 +236,7 @@ export const Widget = withStaticProps(
 
   const dispatch = useDispatch();
   const widgetRef = useRef<HTMLDivElement>(null);
+  const widgetWrapperRef = useRef<HTMLDivElement>(null);
   const [tooltip, setTooltip] = useState<{ text: string; link?: string } | null>(null);
   const causeAreas = useSelector((state: State) => state.layout.causeAreas);
 
@@ -246,6 +248,7 @@ export const Widget = withStaticProps(
 
   const { scaledHeight, scalingFactor } = useWidgetScaleEffect(widgetRef, inline);
   const { scrollPosition } = useWidgetScrollObserver(widgetRef);
+  const widgetHeight = useElementHeight(widgetRef);
 
   useEffect(() => {
     dispatch(fetchCauseAreasAction.started(undefined));
@@ -282,68 +285,77 @@ export const Widget = withStaticProps(
 
   return (
     <div
-      className="widget"
-      ref={widgetRef}
+      className="widget-wrapper"
+      ref={widgetWrapperRef}
       style={{
-        transform: `scale(${scalingFactor})`,
-        height: inline ? "auto" : `${scaledHeight}px`,
-        flexBasis: inline ? "auto" : `${scaledHeight}px`,
+        height: inline ? `${widgetHeight * scalingFactor}px` : "auto",
       }}
     >
-      <WidgetTooltipContext.Provider value={[tooltip, setTooltip]}>
-        {tooltip !== null && (
-          <TooltipWrapper top={20 + scrollPosition}>
-            <TooltipContent>{tooltip.text}</TooltipContent>
-            {tooltip.link && (
-              <TooltipLink href={tooltip.link} target="_blank">
-                {tooltipReadmoreText} ↗
-              </TooltipLink>
-            )}
-          </TooltipWrapper>
-        )}
-        <ProgressBar inline={inline} />
-        <Carousel minHeight={inline ? 0 : scaledHeight - 116}>
-          <DonationPane
-            text={{
-              single_donation_text: widget.single_donation_text,
-              monthly_donation_text: widget.monthly_donation_text,
-              amount_context: widget.amount_context,
-              smart_distribution_context: widget.smart_distribution_context,
-              pane1_button_text: widget.pane1_button_text,
-              donation_input_error_templates: widget.donation_input_error_templates,
-            }}
-            enableRecurring={availableRecurringOptions.recurring}
-            enableSingle={availableRecurringOptions.single}
-          />
-          <DonorPane
-            locale={widget.locale}
-            text={{
-              anon_button_text: widget.anon_button_text,
-              anon_button_text_tooltip: widget.anon_button_text_tooltip,
-              name_placeholder: widget.name_placeholder,
-              name_invalid_error_text: widget.name_invalid_error_text,
-              email_placeholder: widget.email_placeholder,
-              email_invalid_error_text: widget.email_invalid_error_text,
-              tax_deduction_selector_text: widget.tax_deduction_selector_text,
-              tax_deduction_ssn_placeholder: widget.tax_deduction_ssn_placeholder,
-              tax_deduction_ssn_invalid_error_text: widget.tax_deduction_ssn_invalid_error_text,
-              tax_deduction_tooltip_text: widget.tax_deduction_tooltip_text,
-              newsletter_selector_text: widget.newsletter_selector_text,
-              privacy_policy_text: widget.privacy_policy_text,
-              privacy_policy_link: widget.privacy_policy_link,
-              pane2_button_text: widget.pane2_button_text,
-            }}
-            paymentMethods={availablePaymentMethods}
-          />
-          <PaymentPane
-            referrals={{
-              referrals_title: widget.referrals_title,
-              other_referral_input_placeholder: widget.other_referral_input_placeholder,
-            }}
-            paymentMethods={availablePaymentMethods}
-          />
-        </Carousel>
-      </WidgetTooltipContext.Provider>
+      <div
+        className="widget"
+        ref={widgetRef}
+        style={{
+          transform: `scale(${scalingFactor})`,
+          height: inline ? "auto" : `${scaledHeight}px`,
+          flexBasis: inline ? "auto" : `${scaledHeight}px`,
+          transformOrigin: inline ? "top" : undefined,
+        }}
+      >
+        <WidgetTooltipContext.Provider value={[tooltip, setTooltip]}>
+          {tooltip !== null && (
+            <TooltipWrapper top={20 + scrollPosition}>
+              <TooltipContent>{tooltip.text}</TooltipContent>
+              {tooltip.link && (
+                <TooltipLink href={tooltip.link} target="_blank">
+                  {tooltipReadmoreText} ↗
+                </TooltipLink>
+              )}
+            </TooltipWrapper>
+          )}
+          <ProgressBar inline={inline} />
+          <Carousel minHeight={inline ? 0 : scaledHeight - 116}>
+            <DonationPane
+              text={{
+                single_donation_text: widget.single_donation_text,
+                monthly_donation_text: widget.monthly_donation_text,
+                amount_context: widget.amount_context,
+                smart_distribution_context: widget.smart_distribution_context,
+                pane1_button_text: widget.pane1_button_text,
+                donation_input_error_templates: widget.donation_input_error_templates,
+              }}
+              enableRecurring={availableRecurringOptions.recurring}
+              enableSingle={availableRecurringOptions.single}
+            />
+            <DonorPane
+              locale={widget.locale}
+              text={{
+                anon_button_text: widget.anon_button_text,
+                anon_button_text_tooltip: widget.anon_button_text_tooltip,
+                name_placeholder: widget.name_placeholder,
+                name_invalid_error_text: widget.name_invalid_error_text,
+                email_placeholder: widget.email_placeholder,
+                email_invalid_error_text: widget.email_invalid_error_text,
+                tax_deduction_selector_text: widget.tax_deduction_selector_text,
+                tax_deduction_ssn_placeholder: widget.tax_deduction_ssn_placeholder,
+                tax_deduction_ssn_invalid_error_text: widget.tax_deduction_ssn_invalid_error_text,
+                tax_deduction_tooltip_text: widget.tax_deduction_tooltip_text,
+                newsletter_selector_text: widget.newsletter_selector_text,
+                privacy_policy_text: widget.privacy_policy_text,
+                privacy_policy_link: widget.privacy_policy_link,
+                pane2_button_text: widget.pane2_button_text,
+              }}
+              paymentMethods={availablePaymentMethods}
+            />
+            <PaymentPane
+              referrals={{
+                referrals_title: widget.referrals_title,
+                other_referral_input_placeholder: widget.other_referral_input_placeholder,
+              }}
+              paymentMethods={availablePaymentMethods}
+            />
+          </Carousel>
+        </WidgetTooltipContext.Provider>
+      </div>
     </div>
   );
 });

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -33,6 +33,7 @@ import {
 } from "./shared/ProgressBar/ProgressBar.style";
 import { usePrefilledDistribution, usePrefilledSum, useQueryParamsPrefill } from "./hooks";
 import { useElementHeight } from "../../../../../hooks/useElementHeight";
+import { PrefilledDistribution } from "../../../../main/layout/WidgetPane/WidgetPane";
 
 export const widgetContentQuery = groq`
 ...,
@@ -211,7 +212,15 @@ const useWidgetScaleEffect = (widgetRef: React.RefObject<HTMLDivElement>, inline
 };
 
 export const Widget = withStaticProps(
-  async ({ draftMode, inline }: { draftMode: boolean; inline?: boolean }) => {
+  async ({
+    draftMode,
+    inline,
+    prefilled,
+  }: {
+    draftMode: boolean;
+    inline?: boolean;
+    prefilled?: PrefilledDistribution;
+  }) => {
     const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
 
     if (!result.methods?.length) {
@@ -224,9 +233,10 @@ export const Widget = withStaticProps(
         query: widgetQuery,
       },
       inline: inline ?? false,
+      prefilled: prefilled ?? null,
     };
   },
-)(({ data, inline = false }) => {
+)(({ data, inline = false, prefilled }) => {
   const widget = data.result;
   const methods = data.result.methods;
 
@@ -258,6 +268,7 @@ export const Widget = withStaticProps(
   usePrefilledDistribution({
     inline,
     distributionCauseAreas,
+    prefilledDistribution: prefilled,
   });
 
   usePrefilledSum({
@@ -289,6 +300,7 @@ export const Widget = withStaticProps(
       ref={widgetWrapperRef}
       style={{
         height: inline ? `${widgetHeight * scalingFactor}px` : "auto",
+        width: scalingFactor * 576,
       }}
     >
       <div
@@ -298,7 +310,7 @@ export const Widget = withStaticProps(
           transform: `scale(${scalingFactor})`,
           height: inline ? "auto" : `${scaledHeight}px`,
           flexBasis: inline ? "auto" : `${scaledHeight}px`,
-          transformOrigin: inline ? "top" : undefined,
+          transformOrigin: inline ? "top left" : undefined,
         }}
       >
         <WidgetTooltipContext.Provider value={[tooltip, setTooltip]}>

--- a/components/shared/components/Widget/components/WidgetWithStore.tsx
+++ b/components/shared/components/Widget/components/WidgetWithStore.tsx
@@ -14,7 +14,10 @@ import { widgetQuery } from "./Widget";
 import { WidgetProps } from "../types/WidgetProps";
 import { token } from "../../../../../token";
 import dynamic from "next/dynamic";
-import { WidgetPaneProps } from "../../../../main/layout/WidgetPane/WidgetPane";
+import {
+  PrefilledDistribution,
+  WidgetPaneProps,
+} from "../../../../main/layout/WidgetPane/WidgetPane";
 
 const Widget = dynamic<WidgetPaneProps>(() => import("./Widget").then((mod) => mod.Widget), {
   ssr: false,
@@ -50,7 +53,17 @@ export const WidgetStoreProvider: React.FC<{
 
 // Modified Widget component that uses the store provider
 export const WidgetWithStore = withStaticProps(
-  async ({ draftMode, inline }: { draftMode: boolean; inline?: boolean }) => {
+  async ({
+    draftMode,
+    inline,
+    prefilled,
+    prefilledSum,
+  }: {
+    draftMode: boolean;
+    inline?: boolean;
+    prefilled?: PrefilledDistribution;
+    prefilledSum?: number;
+  }) => {
     const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
 
     if (!result.methods?.length) {
@@ -63,12 +76,14 @@ export const WidgetWithStore = withStaticProps(
         query: widgetQuery,
       },
       inline: inline ?? false,
+      prefilled: prefilled ?? null,
+      prefilledSum: prefilledSum ?? null,
     };
   },
-)(({ data, inline = false }) => {
+)(({ data, inline = false, prefilled, prefilledSum }) => {
   return (
     <WidgetStoreProvider isInline={inline}>
-      <Widget data={data} inline={inline} prefilled={null} prefilledSum={null} />
+      <Widget data={data} inline={inline} prefilled={prefilled} prefilledSum={prefilledSum} />
     </WidgetStoreProvider>
   );
 });

--- a/components/shared/components/Widget/components/WidgetWithStore.tsx
+++ b/components/shared/components/Widget/components/WidgetWithStore.tsx
@@ -18,6 +18,7 @@ import {
   PrefilledDistribution,
   WidgetPaneProps,
 } from "../../../../main/layout/WidgetPane/WidgetPane";
+import { RecurringDonation } from "../types/Enums";
 
 const Widget = dynamic<WidgetPaneProps>(() => import("./Widget").then((mod) => mod.Widget), {
   ssr: false,
@@ -58,11 +59,13 @@ export const WidgetWithStore = withStaticProps(
     inline,
     prefilled,
     prefilledSum,
+    defaultPaymentType,
   }: {
     draftMode: boolean;
     inline?: boolean;
     prefilled?: PrefilledDistribution;
     prefilledSum?: number;
+    defaultPaymentType?: RecurringDonation;
   }) => {
     const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
 
@@ -78,12 +81,19 @@ export const WidgetWithStore = withStaticProps(
       inline: inline ?? false,
       prefilled: prefilled ?? null,
       prefilledSum: prefilledSum ?? null,
+      defaultPaymentType: defaultPaymentType ?? RecurringDonation.NON_RECURRING,
     };
   },
-)(({ data, inline = false, prefilled, prefilledSum }) => {
+)(({ data, inline = false, prefilled, prefilledSum, defaultPaymentType }) => {
   return (
     <WidgetStoreProvider isInline={inline}>
-      <Widget data={data} inline={inline} prefilled={prefilled} prefilledSum={prefilledSum} />
+      <Widget
+        data={data}
+        inline={inline}
+        prefilled={prefilled}
+        prefilledSum={prefilledSum}
+        defaultPaymentType={defaultPaymentType}
+      />
     </WidgetStoreProvider>
   );
 });

--- a/components/shared/components/Widget/components/WidgetWithStore.tsx
+++ b/components/shared/components/Widget/components/WidgetWithStore.tsx
@@ -1,0 +1,68 @@
+import { Tuple, combineReducers, configureStore } from "@reduxjs/toolkit";
+import createSagaMiddleware from "redux-saga";
+import { Provider } from "react-redux";
+import { State } from "../store/state";
+import { donationReducer } from "../store/donation/reducer";
+import { layoutReducer } from "../store/layout/reducer";
+import { errorReducer } from "../store/error/reducer";
+import { referralReducer } from "../store/referrals/reducer";
+import { watchAll } from "../store/root.saga";
+import { useMemo } from "react";
+import { getClient } from "../../../../../lib/sanity.client";
+import { withStaticProps } from "../../../../../util/withStaticProps";
+import { Widget, widgetQuery } from "./Widget";
+import { WidgetProps } from "../types/WidgetProps";
+import { token } from "../../../../../token";
+
+// Create a store factory function
+export const createWidgetStore = () => {
+  const sagaMiddleware = createSagaMiddleware();
+  const store = configureStore<State>({
+    reducer: combineReducers({
+      donation: donationReducer,
+      layout: layoutReducer,
+      error: errorReducer,
+      referrals: referralReducer,
+    }) as any,
+    middleware: () => new Tuple(sagaMiddleware),
+  });
+
+  sagaMiddleware.run(watchAll);
+  return store;
+};
+
+// Create a wrapper component that provides its own store
+export const WidgetStoreProvider: React.FC<{
+  children: React.ReactNode;
+  isInline?: boolean;
+}> = ({ children, isInline }) => {
+  // Create a new store instance for this widget
+  const store = useMemo(() => createWidgetStore(), []);
+
+  return <Provider store={store}>{children}</Provider>;
+};
+
+// Modified Widget component that uses the store provider
+export const WidgetWithStore = withStaticProps(
+  async ({ draftMode, inline }: { draftMode: boolean; inline?: boolean }) => {
+    const result = await getClient(draftMode ? token : undefined).fetch<WidgetProps>(widgetQuery);
+
+    if (!result.methods?.length) {
+      throw new Error("No payment methods found");
+    }
+
+    return {
+      data: {
+        result,
+        query: widgetQuery,
+      },
+      inline: inline ?? false,
+    };
+  },
+)(({ data, inline = false }) => {
+  return (
+    <WidgetStoreProvider isInline={inline}>
+      <Widget data={data} inline={inline} />
+    </WidgetStoreProvider>
+  );
+});

--- a/components/shared/components/Widget/components/WidgetWithStore.tsx
+++ b/components/shared/components/Widget/components/WidgetWithStore.tsx
@@ -10,9 +10,15 @@ import { watchAll } from "../store/root.saga";
 import { useMemo } from "react";
 import { getClient } from "../../../../../lib/sanity.client";
 import { withStaticProps } from "../../../../../util/withStaticProps";
-import { Widget, widgetQuery } from "./Widget";
+import { widgetQuery } from "./Widget";
 import { WidgetProps } from "../types/WidgetProps";
 import { token } from "../../../../../token";
+import dynamic from "next/dynamic";
+import { WidgetPaneProps } from "../../../../main/layout/WidgetPane/WidgetPane";
+
+const Widget = dynamic<WidgetPaneProps>(() => import("./Widget").then((mod) => mod.Widget), {
+  ssr: false,
+});
 
 // Create a store factory function
 export const createWidgetStore = () => {
@@ -62,7 +68,7 @@ export const WidgetWithStore = withStaticProps(
 )(({ data, inline = false }) => {
   return (
     <WidgetStoreProvider isInline={inline}>
-      <Widget data={data} inline={inline} />
+      <Widget data={data} inline={inline} prefilled={null} prefilledSum={null} />
     </WidgetStoreProvider>
   );
 });

--- a/components/shared/components/Widget/components/hooks.ts
+++ b/components/shared/components/Widget/components/hooks.ts
@@ -1,5 +1,5 @@
-import { useContext, useEffect, useRef } from "react";
-import { useDispatch } from "react-redux";
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
 import { useRouter } from "next/router";
 import {
   setCauseAreaPercentageShare,
@@ -13,6 +13,10 @@ import { WidgetContext } from "../../../../main/layout/layout";
 import { PrefilledDistribution } from "../../../../main/layout/WidgetPane/WidgetPane";
 import { CauseArea } from "../types/CauseArea";
 import { DistributionCauseArea } from "../types/DistributionCauseArea";
+import { WidgetProps } from "../types/WidgetProps";
+import { paymentMethodConfigurations } from "../config/methods";
+import { useDebouncedCallback } from "use-debounce";
+import { State } from "../store/state";
 
 interface UsePrefilledDistributionProps {
   inline: boolean;
@@ -100,9 +104,11 @@ export const usePrefilledSum = ({ inline }: { inline: boolean }) => {
 export const useQueryParamsPrefill = ({
   inline,
   causeAreas,
+  defaultPaymentType,
 }: {
   inline: boolean;
   causeAreas: CauseArea[] | undefined;
+  defaultPaymentType: RecurringDonation;
 }) => {
   const router = useRouter();
   const dispatch = useDispatch();
@@ -129,6 +135,10 @@ export const useQueryParamsPrefill = ({
       setWidgetContext({ ...widgetContext, open: true });
     }
   }, [inline, router.query, causeAreas, dispatch, setWidgetContext, widgetContext]);
+
+  useEffect(() => {
+    dispatch(setRecurring(defaultPaymentType));
+  }, [defaultPaymentType, dispatch]);
 };
 
 // Helper functions
@@ -183,4 +193,133 @@ const parseDistributionQueryParam = (distribution: string): PrefilledDistributio
       }),
     };
   });
+};
+
+/**
+ * Determine available recurring options based on the configured payment methods
+ */
+export const useAvailableRecurringOptions = (
+  paymentMethods: NonNullable<WidgetProps["methods"]>,
+) => {
+  const recurring = useMemo(
+    () =>
+      paymentMethods.some((method) => {
+        const configuration = paymentMethodConfigurations.find(
+          (config) => config.id === method._id,
+        );
+        return configuration?.recurringOptions.includes(RecurringDonation.RECURRING);
+      }),
+    [paymentMethods],
+  );
+
+  const single = useMemo(
+    () =>
+      paymentMethods.some((method) => {
+        const configuration = paymentMethodConfigurations.find(
+          (config) => config.id === method._id,
+        );
+        return configuration?.recurringOptions.includes(RecurringDonation.NON_RECURRING);
+      }),
+    [paymentMethods],
+  );
+
+  return useMemo(() => ({ recurring, single }), [recurring, single]);
+};
+
+/**
+ * Determine available payment methods based on the selected recurring option
+ */
+export const useAvailablePaymentMethods = (paymentMethods: NonNullable<WidgetProps["methods"]>) => {
+  const recurring = useSelector((state: State) => state.donation.recurring);
+
+  const availablePaymentMethods = useMemo(
+    () =>
+      paymentMethods.filter((method) => {
+        const configuration = paymentMethodConfigurations.find(
+          (config) => config.id === method._id,
+        );
+        return configuration?.recurringOptions.includes(recurring);
+      }),
+    [paymentMethods, recurring],
+  );
+
+  return availablePaymentMethods;
+};
+
+/**
+ * This effect is used to set the default payment method to single if recurring is not enabled
+ */
+export const useDefaultPaymentMethodEffect = (
+  paymentMethods: NonNullable<WidgetProps["methods"]>,
+) => {
+  const dispatch = useDispatch();
+  const recurring = useSelector((state: State) => state.donation.recurring);
+
+  const availableRecurringOptions = useAvailableRecurringOptions(paymentMethods);
+
+  useEffect(() => {
+    if (recurring === RecurringDonation.RECURRING && !availableRecurringOptions.recurring) {
+      dispatch(setRecurring(RecurringDonation.NON_RECURRING));
+    }
+  }, [recurring, availableRecurringOptions.recurring, dispatch]);
+};
+
+/**
+ * Scale the widget to fit the screen
+ */
+export const useWidgetScaleEffect = (
+  widgetRef: React.RefObject<HTMLDivElement>,
+  inline: boolean,
+) => {
+  const [widgetContext, setWidgetContext] = useContext(WidgetContext);
+  const [scalingFactor, setScalingFactor] = useState(1);
+  const [scaledHeight, setScaledHeight] = useState(979);
+  const [lastHeight, setLastHeight] = useState(979);
+  const [lastWidth, setLastWidth] = useState(400);
+
+  const scaleWidget = useCallback(() => {
+    if (!inline || window.innerWidth < 1180) {
+      setScalingFactor(
+        (window.innerWidth >= 1180 ? Math.min(window.innerWidth * 0.4, 720) : window.innerWidth) /
+          576,
+      );
+      setScaledHeight(Math.ceil(window.innerHeight / scalingFactor));
+      if (window.innerHeight != lastHeight && window.innerWidth == lastWidth) {
+        // This is probably the android keyboard opening
+        const delta = lastHeight - window.innerHeight;
+        if (delta > 0) widgetRef.current?.scrollTo(0, Math.ceil(delta / scalingFactor));
+        else widgetRef.current?.scrollTo(0, 0);
+      }
+      setLastWidth(window.innerWidth);
+      setLastHeight(window.innerHeight);
+    }
+  }, [
+    setScalingFactor,
+    setScaledHeight,
+    scalingFactor,
+    scaledHeight,
+    setLastWidth,
+    setLastHeight,
+    inline,
+  ]);
+
+  useEffect(() => scaleWidget, [widgetContext.open, scaleWidget]);
+
+  const debouncedScaleWidget = useDebouncedCallback(() => scaleWidget(), 1000, { maxWait: 1000 });
+
+  useEffect(() => {
+    if (!inline) {
+      window.addEventListener("resize", debouncedScaleWidget);
+
+      return () => {
+        window.removeEventListener("resize", debouncedScaleWidget);
+      };
+    }
+  }, [debouncedScaleWidget, inline]);
+
+  useEffect(() => {
+    scaleWidget();
+  }, [widgetContext, scaleWidget]);
+
+  return useMemo(() => ({ scaledHeight, scalingFactor }), [scaledHeight, scalingFactor]);
 };

--- a/components/shared/components/Widget/components/hooks.ts
+++ b/components/shared/components/Widget/components/hooks.ts
@@ -58,7 +58,8 @@ export const usePrefilledDistribution = ({
     }
 
     // Only apply prefill once to avoid overwriting user changes
-    if (hasAppliedPrefill.current) {
+    // Except if the prefill comes from the context, then we need to reapply it
+    if (hasAppliedPrefill.current && !widgetContext.prefilled) {
       return;
     }
 
@@ -76,7 +77,7 @@ export const usePrefilledDistribution = ({
 
     // Mark that we've applied the prefill
     hasAppliedPrefill.current = true;
-  }, [inline, widgetContext.prefilled, prefilledDistribution, distributionCauseAreas, dispatch]);
+  }, [inline, widgetContext.prefilled, prefilledDistribution, dispatch]);
 
   // Reset the ref if prefilled data changes
   useEffect(() => {

--- a/components/shared/components/Widget/components/hooks.ts
+++ b/components/shared/components/Widget/components/hooks.ts
@@ -1,0 +1,154 @@
+import { useContext, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { useRouter } from "next/router";
+import {
+  setCauseAreaPercentageShare,
+  setShareType,
+  setShares,
+  setSum,
+  setRecurring,
+} from "../store/donation/actions";
+import { RecurringDonation } from "../types/Enums";
+import { WidgetContext, WidgetContextType } from "../../../../main/layout/layout";
+import { PrefilledDistribution } from "../../../../main/layout/WidgetPane/WidgetPane";
+import { CauseArea } from "../types/CauseArea";
+import { DistributionCauseArea } from "../types/DistributionCauseArea";
+
+interface UsePrefilledDistributionProps {
+  inline: boolean;
+  distributionCauseAreas: DistributionCauseArea[];
+}
+
+/**
+ * Hook to handle prefilled distribution data for the widget
+ */
+export const usePrefilledDistribution = ({
+  inline,
+  distributionCauseAreas,
+}: UsePrefilledDistributionProps) => {
+  const dispatch = useDispatch();
+  const [widgetContext, setWidgetContext] = useContext(WidgetContext);
+
+  useEffect(() => {
+    if (inline || !widgetContext.prefilled || distributionCauseAreas.length === 0) {
+      return;
+    }
+
+    const prefilled = widgetContext.prefilled;
+
+    distributionCauseAreas.forEach((causeArea) => {
+      const prefilledCauseArea = prefilled.find(
+        (prefilledArea) => prefilledArea.causeAreaId === causeArea.id,
+      );
+
+      if (prefilledCauseArea) {
+        handlePrefilledCauseArea(dispatch, causeArea, prefilledCauseArea);
+      } else {
+        resetCauseArea(dispatch, causeArea);
+      }
+    });
+  }, [inline, widgetContext.prefilled, distributionCauseAreas, dispatch]);
+};
+
+/**
+ * Hook to handle prefilled sum for the widget
+ */
+export const usePrefilledSum = ({ inline }: { inline: boolean }) => {
+  const dispatch = useDispatch();
+  const [widgetContext, setWidgetContext] = useContext(WidgetContext);
+
+  useEffect(() => {
+    if (!inline && widgetContext.prefilledSum !== null) {
+      dispatch(setSum(widgetContext.prefilledSum));
+    }
+  }, [inline, widgetContext.prefilledSum, dispatch]);
+};
+
+/**
+ * Hook to handle URL query parameters for prefilling the widget
+ */
+export const useQueryParamsPrefill = ({
+  inline,
+  causeAreas,
+}: {
+  inline: boolean;
+  causeAreas: CauseArea[] | undefined;
+}) => {
+  const router = useRouter();
+  const dispatch = useDispatch();
+  const [widgetContext, setWidgetContext] = useContext(WidgetContext);
+
+  useEffect(() => {
+    if (inline || !router.query || !causeAreas) {
+      return;
+    }
+
+    const { distribution, recurring } = router.query;
+
+    if (distribution && typeof distribution === "string") {
+      const prefilledDistribution = parseDistributionQueryParam(distribution);
+      setWidgetContext({
+        open: true,
+        prefilled: prefilledDistribution,
+        prefilledSum: null,
+      });
+    }
+
+    if (recurring) {
+      dispatch(setRecurring(RecurringDonation.RECURRING));
+      setWidgetContext({ ...widgetContext, open: true });
+    }
+  }, [inline, router.query, causeAreas, dispatch, setWidgetContext, widgetContext]);
+};
+
+// Helper functions
+
+const handlePrefilledCauseArea = (
+  dispatch: any,
+  causeArea: DistributionCauseArea,
+  prefilledCauseArea: PrefilledDistribution[number],
+) => {
+  dispatch(setCauseAreaPercentageShare(causeArea.id, prefilledCauseArea.share.toString()));
+  dispatch(setShareType(causeArea.id, false));
+
+  const newCauseAreaOrganizations = causeArea.organizations.map((organization) => {
+    const prefilledOrg = prefilledCauseArea.organizations.find(
+      (prefOrg) => prefOrg.organizationId === organization.id,
+    );
+    return {
+      ...organization,
+      percentageShare: prefilledOrg ? prefilledOrg.share.toString() : "0",
+    };
+  });
+
+  dispatch(setShares(causeArea.id, newCauseAreaOrganizations));
+};
+
+const resetCauseArea = (dispatch: any, causeArea: DistributionCauseArea) => {
+  dispatch(setCauseAreaPercentageShare(causeArea.id, "0"));
+  dispatch(setShareType(causeArea.id, true));
+
+  const resetOrganizations = causeArea.organizations.map((organization) => ({
+    ...organization,
+    percentageShare: "0",
+  }));
+
+  dispatch(setShares(causeArea.id, resetOrganizations));
+};
+
+const parseDistributionQueryParam = (distribution: string): PrefilledDistribution => {
+  return distribution.split(",").map((prefilledCauseArea) => {
+    const [causeAreaId, share, ...organizations] = prefilledCauseArea.split(":");
+    return {
+      causeAreaId: parseInt(causeAreaId),
+      share: parseFloat(share),
+      organizations: organizations.map((organization) => {
+        const [organizationId, share] = organization.split("-");
+        return {
+          organizationId: parseInt(organizationId),
+          share: parseFloat(share),
+        };
+      }),
+    };
+  });
+};

--- a/components/shared/components/Widget/components/panes/DonationPane/DonationPane.tsx
+++ b/components/shared/components/Widget/components/panes/DonationPane/DonationPane.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useId, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { setSum, setRecurring } from "../../../store/donation/actions";
 import { Pane, PaneContainer, PaneTitle } from "../Panes.style";
@@ -33,6 +33,7 @@ export const DonationPane: React.FC<{
   const donation = useSelector((state: State) => state.donation);
   const layout = useSelector((state: State) => state.layout);
   const plausible = usePlausible();
+  const sumInputId = useId();
   const [showErrors, setShowErrors] = useState(false);
 
   const suggestedSums = donation.recurring
@@ -56,8 +57,6 @@ export const DonationPane: React.FC<{
   if (showErrors) {
     errorTexts = getErrorTexts(donation, text.donation_input_error_templates);
   }
-
-  console.log(donation.recurring);
 
   return (
     <Pane>
@@ -118,10 +117,10 @@ export const DonationPane: React.FC<{
               errorTexts.find((error) => error.error.type === "donationSumError")?.error.type
             }
           >
-            <label htmlFor="sum">{text.amount_context.custom_amount_text}</label>
+            <label htmlFor={sumInputId}>{text.amount_context.custom_amount_text}</label>
             <span>
               <input
-                name="sum"
+                name={sumInputId}
                 type="tel"
                 placeholder="0"
                 value={donation.sum && donation.sum > 0 ? donation.sum : ""}

--- a/components/shared/components/Widget/components/panes/DonationPane/DonationPane.tsx
+++ b/components/shared/components/Widget/components/panes/DonationPane/DonationPane.tsx
@@ -57,6 +57,8 @@ export const DonationPane: React.FC<{
     errorTexts = getErrorTexts(donation, text.donation_input_error_templates);
   }
 
+  console.log(donation.recurring);
+
   return (
     <Pane>
       <PaneContainer>

--- a/components/shared/components/Widget/components/panes/DonationPane/ShareSelector/ShareSelection.tsx
+++ b/components/shared/components/Widget/components/panes/DonationPane/ShareSelector/ShareSelection.tsx
@@ -56,16 +56,11 @@ export const SharesSelection: React.FC<{
   if (!distributionCauseArea) return <div>Ingen fordeling for saksområde</div>;
   if (!organizations) return <div>Ingen organisasjoner</div>;
 
-  const prefilledShares = distributionCauseArea.organizations.filter((org) =>
-    widgetContext.prefilled
-      ?.find((causeArea) => causeArea.causeAreaId === distributionCauseArea.id)
-      ?.organizations.find((o) => o.organizationId === org.id),
+  const prefilledShares = distributionCauseArea.organizations.filter(
+    (org) => typeof org.prefilledPercentageShare === "string",
   );
   const nonPrefilledShares = distributionCauseArea.organizations.filter(
-    (org) =>
-      !widgetContext.prefilled
-        ?.find((causeArea) => causeArea.causeAreaId === distributionCauseArea.id)
-        ?.organizations.find((o) => o.organizationId === org.id),
+    (org) => typeof org.prefilledPercentageShare === "undefined",
   );
 
   return (

--- a/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
+++ b/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
@@ -148,8 +148,6 @@ export const DonorPane: React.FC<{
     }
   });
 
-  console.log(errors, isValid);
-
   return (
     <Pane>
       <DonorForm onSubmit={paneSubmitted} autoComplete="on">
@@ -187,7 +185,12 @@ export const DonorPane: React.FC<{
                   data-cy="name-input"
                   type="text"
                   placeholder={text.name_placeholder}
-                  {...register("name", { required: isAnonymous ? false : true, minLength: 3 })}
+                  {...register("name", {
+                    validate: (val, formValues) => {
+                      if (formValues.isAnonymous) return true;
+                      return val.trim().length > 3;
+                    },
+                  })}
                 />
                 {errors.name && <ErrorField text={text.name_invalid_error_text} />}
               </InputFieldWrapper>
@@ -197,9 +200,8 @@ export const DonorPane: React.FC<{
                   type="email"
                   placeholder={text.email_placeholder}
                   {...register("email", {
-                    required: isAnonymous ? false : true,
-                    validate: (val) => {
-                      if (isAnonymous) return true;
+                    validate: (val, formValues) => {
+                      if (formValues.isAnonymous) return true;
                       const trimmed = val.trim();
                       return /@/.test(trimmed);
                     },
@@ -247,9 +249,10 @@ export const DonorPane: React.FC<{
                         placeholder={text.tax_deduction_ssn_placeholder}
                         {...register("ssn", {
                           required: false,
-                          validate: (val) => {
+                          validate: (val, formValues) => {
+                            if (formValues.isAnonymous || !taxDeductionChecked) return true;
                             const trimmed = val.toString().trim();
-                            if (taxDeductionChecked && !isAnonymous) {
+                            if (taxDeductionChecked) {
                               if (locale === "no") {
                                 return validateSsnNo(trimmed);
                               } else if (locale === "sv") {

--- a/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
+++ b/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
@@ -148,6 +148,8 @@ export const DonorPane: React.FC<{
     }
   });
 
+  console.log(errors, isValid);
+
   return (
     <Pane>
       <DonorForm onSubmit={paneSubmitted} autoComplete="on">
@@ -185,7 +187,7 @@ export const DonorPane: React.FC<{
                   data-cy="name-input"
                   type="text"
                   placeholder={text.name_placeholder}
-                  {...register("name", { required: true, minLength: 3 })}
+                  {...register("name", { required: isAnonymous ? false : true, minLength: 3 })}
                 />
                 {errors.name && <ErrorField text={text.name_invalid_error_text} />}
               </InputFieldWrapper>
@@ -195,8 +197,9 @@ export const DonorPane: React.FC<{
                   type="email"
                   placeholder={text.email_placeholder}
                   {...register("email", {
-                    required: true,
+                    required: isAnonymous ? false : true,
                     validate: (val) => {
+                      if (isAnonymous) return true;
                       const trimmed = val.trim();
                       return /@/.test(trimmed);
                     },
@@ -246,7 +249,7 @@ export const DonorPane: React.FC<{
                           required: false,
                           validate: (val) => {
                             const trimmed = val.toString().trim();
-                            if (taxDeductionChecked) {
+                            if (taxDeductionChecked && !isAnonymous) {
                               if (locale === "no") {
                                 return validateSsnNo(trimmed);
                               } else if (locale === "sv") {

--- a/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
+++ b/components/shared/components/Widget/components/panes/DonorPane/DonorPane.tsx
@@ -28,6 +28,7 @@ import { API_URL } from "../../../config/api";
 import { getEstimatedLtv } from "../../../../../../../util/ltv";
 import { ExtraMessageWrapper } from "../DonationPane/DonationPane.style";
 import { Info } from "react-feather";
+import AnimateHeight from "react-animate-height";
 
 // Capitalizes each first letter of all first, middle and last names
 const capitalizeNames = (string: string) => {
@@ -178,129 +179,131 @@ export const DonorPane: React.FC<{
               </CheckBoxWrapper>
             </div>
 
-            {!isAnonymous ? (
-              <>
-                <InputFieldWrapper>
-                  <input
-                    data-cy="name-input"
-                    type="text"
-                    placeholder={text.name_placeholder}
-                    {...register("name", { required: true, minLength: 3 })}
-                  />
-                  {errors.name && <ErrorField text={text.name_invalid_error_text} />}
-                </InputFieldWrapper>
-                <InputFieldWrapper>
-                  <input
-                    data-cy="email-input"
-                    type="email"
-                    placeholder={text.email_placeholder}
-                    {...register("email", {
-                      required: true,
-                      validate: (val) => {
-                        const trimmed = val.trim();
-                        return /@/.test(trimmed);
-                      },
-                    })}
-                  />
-                  {errors.email && <ErrorField text={text.email_invalid_error_text} />}
-                </InputFieldWrapper>
-                <CheckBoxGroupWrapper>
-                  <div>
-                    <CheckBoxWrapper>
-                      <HiddenCheckBox
-                        data-cy="tax-deduction-checkbox"
-                        type="checkbox"
-                        onKeyDown={(e) => {
-                          if (!taxDeductionChecked) clearErrors(["ssn"]);
-                          if (e.key === "Enter" || e.key === " ") {
-                            e.preventDefault();
-                          }
-                        }}
-                        {...register("taxDeduction", {
-                          onChange() {
-                            if (!taxDeductionChecked) clearErrors(["ssn"]);
-                            (document.activeElement as HTMLElement).blur();
-                          },
-                        })}
-                      />
-                      <CustomCheckBox
-                        label={text.tax_deduction_selector_text}
-                        checked={taxDeductionChecked}
-                      />
-                      {taxDeductionChecked && <ToolTip text={text.tax_deduction_tooltip_text} />}
-                    </CheckBoxWrapper>
-
-                    {taxDeductionChecked && (
-                      <InputFieldWrapper>
-                        <input
-                          data-cy="ssn-input"
-                          type="text"
-                          inputMode="numeric"
-                          autoComplete="off"
-                          placeholder={text.tax_deduction_ssn_placeholder}
-                          {...register("ssn", {
-                            required: false,
-                            validate: (val) => {
-                              const trimmed = val.toString().trim();
-                              if (taxDeductionChecked) {
-                                if (locale === "no") {
-                                  return validateSsnNo(trimmed);
-                                } else if (locale === "sv") {
-                                  return validateSsnSe(trimmed);
-                                } else {
-                                  return true;
-                                }
-                              } else {
-                                return true;
-                              }
-                            },
-                          })}
-                        />
-                        {errors.ssn && (
-                          <ErrorField text={text.tax_deduction_ssn_invalid_error_text} />
-                        )}
-                      </InputFieldWrapper>
-                    )}
-                  </div>
+            <AnimateHeight height={isAnonymous ? 0 : "auto"} animateOpacity>
+              <InputFieldWrapper>
+                <input
+                  data-cy="name-input"
+                  type="text"
+                  placeholder={text.name_placeholder}
+                  {...register("name", { required: true, minLength: 3 })}
+                />
+                {errors.name && <ErrorField text={text.name_invalid_error_text} />}
+              </InputFieldWrapper>
+              <InputFieldWrapper>
+                <input
+                  data-cy="email-input"
+                  type="email"
+                  placeholder={text.email_placeholder}
+                  {...register("email", {
+                    required: true,
+                    validate: (val) => {
+                      const trimmed = val.trim();
+                      return /@/.test(trimmed);
+                    },
+                  })}
+                />
+                {errors.email && <ErrorField text={text.email_invalid_error_text} />}
+              </InputFieldWrapper>
+              <CheckBoxGroupWrapper>
+                <div>
                   <CheckBoxWrapper>
                     <HiddenCheckBox
-                      data-cy="newsletter-checkbox"
+                      data-cy="tax-deduction-checkbox"
                       type="checkbox"
                       onKeyDown={(e) => {
+                        if (!taxDeductionChecked) clearErrors(["ssn"]);
                         if (e.key === "Enter" || e.key === " ") {
                           e.preventDefault();
                         }
                       }}
-                      {...register("newsletter", {
+                      {...register("taxDeduction", {
                         onChange() {
+                          if (!taxDeductionChecked) clearErrors(["ssn"]);
                           (document.activeElement as HTMLElement).blur();
                         },
                       })}
                     />
                     <CustomCheckBox
-                      label={text.newsletter_selector_text}
-                      mobileLabel={text.newsletter_selector_text}
-                      checked={newsletterChecked}
+                      label={text.tax_deduction_selector_text}
+                      checked={taxDeductionChecked}
                     />
+                    {taxDeductionChecked && <ToolTip text={text.tax_deduction_tooltip_text} />}
                   </CheckBoxWrapper>
-                  {text.privacy_policy_link && (
-                    <div style={{ marginTop: "10px" }}>
-                      {text.privacy_policy_text}{" "}
-                      <Link
-                        href={`/${text.privacy_policy_link.slug}`}
-                        target={"_blank"}
-                        onClick={(e) => {
-                          e.currentTarget.blur();
-                        }}
-                        style={{ borderBottom: "1px solid var(--primary)" }}
-                      >
-                        {`${text.privacy_policy_link.title}  ↗`}
-                      </Link>
-                    </div>
-                  )}
-                </CheckBoxGroupWrapper>
-              </>
-            ) : null}
+
+                  <AnimateHeight
+                    height={taxDeductionChecked ? "auto" : 0}
+                    animateOpacity
+                    duration={200}
+                  >
+                    <InputFieldWrapper>
+                      <input
+                        data-cy="ssn-input"
+                        type="text"
+                        inputMode="numeric"
+                        autoComplete="off"
+                        placeholder={text.tax_deduction_ssn_placeholder}
+                        {...register("ssn", {
+                          required: false,
+                          validate: (val) => {
+                            const trimmed = val.toString().trim();
+                            if (taxDeductionChecked) {
+                              if (locale === "no") {
+                                return validateSsnNo(trimmed);
+                              } else if (locale === "sv") {
+                                return validateSsnSe(trimmed);
+                              } else {
+                                return true;
+                              }
+                            } else {
+                              return true;
+                            }
+                          },
+                        })}
+                      />
+                      {errors.ssn && (
+                        <ErrorField text={text.tax_deduction_ssn_invalid_error_text} />
+                      )}
+                    </InputFieldWrapper>
+                  </AnimateHeight>
+                </div>
+                <CheckBoxWrapper>
+                  <HiddenCheckBox
+                    data-cy="newsletter-checkbox"
+                    type="checkbox"
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                      }
+                    }}
+                    {...register("newsletter", {
+                      onChange() {
+                        (document.activeElement as HTMLElement).blur();
+                      },
+                    })}
+                  />
+                  <CustomCheckBox
+                    label={text.newsletter_selector_text}
+                    mobileLabel={text.newsletter_selector_text}
+                    checked={newsletterChecked}
+                  />
+                </CheckBoxWrapper>
+                {text.privacy_policy_link && (
+                  <div style={{ marginTop: "10px" }}>
+                    {text.privacy_policy_text}{" "}
+                    <Link
+                      href={`/${text.privacy_policy_link.slug}`}
+                      target={"_blank"}
+                      onClick={(e) => {
+                        e.currentTarget.blur();
+                      }}
+                      style={{ borderBottom: "1px solid var(--primary)" }}
+                    >
+                      {`${text.privacy_policy_link.title}  ↗`}
+                    </Link>
+                  </div>
+                )}
+              </CheckBoxGroupWrapper>
+            </AnimateHeight>
 
             <Controller
               control={control}

--- a/components/shared/components/Widget/components/shared/ProgressBar/ProgressBar.tsx
+++ b/components/shared/components/Widget/components/shared/ProgressBar/ProgressBar.tsx
@@ -11,7 +11,7 @@ import {
   ActionButton,
 } from "./ProgressBar.style";
 
-export const ProgressBar: React.FC = () => {
+export const ProgressBar: React.FC<{ inline?: boolean }> = ({ inline }) => {
   const numberOfPanes = 3;
   const dispatch = useDispatch();
   const paneNumber = useSelector((state: State) => state.layout.paneNumber);
@@ -39,15 +39,17 @@ export const ProgressBar: React.FC = () => {
         {points.map((p) => p)}
         <ProgressLine />
       </ProgressContainer>
-      <ActionButton
-        data-cy="close-widget"
-        onClick={(e) => {
-          setWidgetContext({ ...widgetContext, open: false });
-          e.currentTarget.blur();
-        }}
-      >
-        ✕
-      </ActionButton>
+      {!inline && (
+        <ActionButton
+          data-cy="close-widget"
+          onClick={(e) => {
+            setWidgetContext({ ...widgetContext, open: false });
+            e.currentTarget.blur();
+          }}
+        >
+          ✕
+        </ActionButton>
+      )}
     </HeaderContainer>
   );
 };

--- a/components/shared/components/Widget/store/donation/reducer.ts
+++ b/components/shared/components/Widget/store/donation/reducer.ts
@@ -56,7 +56,6 @@ export const donationReducer: Reducer<Donation, DonationActionTypes> = (
   action,
 ) => {
   if (isType(action, fetchCauseAreasAction.done)) {
-    const topOrderedId = action.payload.result.sort((a, b) => a.ordering - b.ordering)[0].id;
     state = {
       ...state,
       distributionCauseAreas: action.payload.result.map((causeArea: CauseArea) => ({
@@ -64,12 +63,14 @@ export const donationReducer: Reducer<Donation, DonationActionTypes> = (
         name: causeArea.name,
         percentageShare: causeArea.standardPercentageShare?.toString() ?? "0",
         standardSplit: true,
-        organizations: causeArea.organizations.map(
-          (org): DistributionCauseAreaOrganization => ({
-            id: org.id,
-            percentageShare: org.standardShare?.toString() ?? "0",
-          }),
-        ),
+        organizations: causeArea.organizations
+          .sort((a, b) => a.ordering - b.ordering)
+          .map(
+            (org): DistributionCauseAreaOrganization => ({
+              id: org.id,
+              percentageShare: org.standardShare?.toString() ?? "0",
+            }),
+          ),
       })),
     };
   }

--- a/components/shared/components/Widget/store/donation/saga.ts
+++ b/components/shared/components/Widget/store/donation/saga.ts
@@ -134,9 +134,16 @@ export function* registerDonation(action: Action<undefined>): SagaIterator<void>
     const donation: Donation = yield select((state: State) => state.donation);
 
     const data: RegisterDonationObject = {
-      distributionCauseAreas: donation.distributionCauseAreas.filter(
-        (c) => parseFloat(c.percentageShare) > 0,
-      ),
+      distributionCauseAreas: donation.distributionCauseAreas
+        .filter((c) => parseFloat(c.percentageShare) > 0)
+        .map((c) => ({
+          ...c,
+          // Removes any potential prefilled data from the submitted data
+          organizations: c.organizations.map((o) => ({
+            id: o.id,
+            percentageShare: o.percentageShare,
+          })),
+        })),
       donor: donation.donor,
       method: donation.method || PaymentMethod.BANK,
       amount: donation.sum || 0,

--- a/components/shared/components/Widget/types/DistributionCauseAreaOrganization.ts
+++ b/components/shared/components/Widget/types/DistributionCauseAreaOrganization.ts
@@ -6,4 +6,7 @@ export type DistributionCauseAreaOrganization = {
   informationUrl?: string;
   /** @description The percentage share for the given organizations in decimal form */
   percentageShare: string;
+  /** @description The prefilled percentage share for the given organizations in decimal
+   * form */
+  prefilledPercentageShare?: string;
 };

--- a/hooks/useElementHeight.ts
+++ b/hooks/useElementHeight.ts
@@ -1,25 +1,24 @@
-import { useEffect, RefObject } from "react";
+import { useState, useEffect, RefObject } from "react";
 
 /**
- * Hook to observe and track an element's height changes
+ * Hook to observe and return an element's height
  * @param elementRef React ref object pointing to the target element
- * @param onHeightChange Callback function to handle height changes
+ * @returns The current height of the element in pixels
  */
-export const useElementHeight = <T extends HTMLElement>(
-  elementRef: RefObject<T>,
-  onHeightChange: (height: number) => void,
-) => {
+export const useElementHeight = <T extends HTMLElement>(elementRef: RefObject<T>): number => {
+  const [height, setHeight] = useState<number>(0);
+
   useEffect(() => {
     const element = elementRef.current;
     if (!element) return;
 
     // Set initial height
-    onHeightChange(element.clientHeight);
+    setHeight(element.clientHeight);
 
     // Create resize observer
     const resizeObserver = new ResizeObserver((entries) => {
       const newHeight = Math.round(entries[0].contentRect.height);
-      onHeightChange(newHeight);
+      setHeight(newHeight);
     });
 
     // Start observing
@@ -29,5 +28,7 @@ export const useElementHeight = <T extends HTMLElement>(
     return () => {
       resizeObserver.disconnect();
     };
-  }, [elementRef.current, onHeightChange]);
+  }, [elementRef]);
+
+  return height;
 };

--- a/pages/_app.page.tsx
+++ b/pages/_app.page.tsx
@@ -1,42 +1,24 @@
 import "../styles/globals.css";
 import type { AppProps } from "next/app";
 import React, { Suspense, lazy, useEffect, useRef } from "react";
-import createSagaMiddleware from "redux-saga";
 import PlausibleProvider from "next-plausible";
-import { State } from "../components/shared/components/Widget/store/state";
-import { donationReducer } from "../components/shared/components/Widget/store/donation/reducer";
-import { layoutReducer } from "../components/shared/components/Widget/store/layout/reducer";
-import { errorReducer } from "../components/shared/components/Widget/store/error/reducer";
-import { watchAll } from "../components/shared/components/Widget/store/root.saga";
-import { referralReducer } from "../components/shared/components/Widget/store/referrals/reducer";
 
 // import { usePreviewSubscription } from "../lib/sanity";
 import { RouterContext, RouterContextValue, fetchRouterContext } from "../context/RouterContext";
 import { ProfileLayout } from "../components/profile/layout/layout";
 import { Layout } from "../components/main/layout/layout";
-import { Tuple, combineReducers, configureStore } from "@reduxjs/toolkit";
 import { Provider } from "react-redux";
 import { VisualEditing } from "next-sanity";
 import { ConsentState } from "../middleware.page";
+import { createWidgetStore } from "../components/shared/components/Widget/components/WidgetWithStore";
 
 const PreviewProvider = lazy(() => import("../components/shared/PreviewProvider"));
+const globalWidgetStore = createWidgetStore();
 
 export enum LayoutType {
   Default = "default",
   Profile = "profile",
 }
-
-const sagaMiddleware = createSagaMiddleware();
-const store = configureStore<State>({
-  reducer: combineReducers({
-    donation: donationReducer,
-    layout: layoutReducer,
-    error: errorReducer,
-    referrals: referralReducer,
-  }) as any,
-  middleware: () => new Tuple(sagaMiddleware),
-});
-sagaMiddleware.run(watchAll);
 
 export type GeneralPageProps = Record<string, unknown> & {
   preview: boolean;
@@ -117,7 +99,7 @@ function MyApp({
           trackLocalhost={false}
           enabled={tracking}
         >
-          <Provider store={store}>
+          <Provider store={globalWidgetStore}>
             <RouterContext.Provider value={routerContextValue.current}>
               {appStaticProps.layout === LayoutType.Default ? (
                 <Layout {...appStaticProps.layoutProps}>
@@ -145,7 +127,7 @@ function MyApp({
       taggedEvents={true}
       revenue={true}
     >
-      <Provider store={store}>
+      <Provider store={globalWidgetStore}>
         <RouterContext.Provider value={routerContextValue.current}>
           {appStaticProps.layout === LayoutType.Default ? (
             <Layout {...appStaticProps.layoutProps}>

--- a/studio/components/distributionInput.tsx
+++ b/studio/components/distributionInput.tsx
@@ -1,0 +1,451 @@
+import React, { useEffect, useState } from "react";
+import { Box, Stack, Card, Text, Button, Select, Label, TextInput, Flex } from "@sanity/ui";
+import { PatchEvent, set, unset } from "sanity";
+import { TrashIcon, AddIcon } from "@sanity/icons";
+
+// Types for our data structures
+type CauseArea = {
+  id: number;
+  name: string;
+  isActive: boolean;
+  standardPercentageShare: number;
+  organizations: Organization[];
+};
+
+type Organization = {
+  id: number;
+  name: string;
+  widgetDisplayName: string | null;
+  standardShare: number;
+  isActive: boolean;
+  ordering: number;
+  causeAreaId: number;
+};
+
+// Updated to include _key property
+type DistributionItem = {
+  _key: string; // Required by Sanity for array items
+  type: "causeArea" | "organization";
+  id: number;
+  causeAreaId?: number;
+  percentage: number;
+  name?: string; // Store name for display purposes
+};
+
+interface DistributionInputProps {
+  value?: DistributionItem[];
+  onChange: (event: PatchEvent) => void;
+}
+
+// Helper function to generate a unique key
+const generateKey = (): string => {
+  return Math.random().toString(36).substring(2, 15);
+};
+
+// Helper function to ensure all items have _key properties
+const ensureKeys = (items: any[]): DistributionItem[] => {
+  return items.map((item) => {
+    if (!item._key) {
+      return {
+        ...item,
+        _key: generateKey(),
+      };
+    }
+    return item;
+  });
+};
+
+// DistributionInput Component (main input component for Sanity)
+export const DistributionInput = React.forwardRef<HTMLDivElement, DistributionInputProps>(
+  (props, ref) => {
+    // Ensure all initial values have _key property
+    const initialDistributions = props.value ? ensureKeys(props.value) : [];
+
+    const [distributions, setDistributions] = useState<DistributionItem[]>(initialDistributions);
+    const [causeAreas, setCauseAreas] = useState<CauseArea[]>([]);
+    const [allCauseAreas, setAllCauseAreas] = useState<CauseArea[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    // Fetch all cause areas and organizations for displaying names
+    useEffect(() => {
+      setLoading(true);
+      fetch("http://localhost:5050/causeareas/all")
+        .then((response) => response.json())
+        .then((data) => {
+          if (data && data.content) {
+            const activeCauseAreas = data.content.filter((area: CauseArea) => area.isActive);
+            setAllCauseAreas(data.content);
+            setCauseAreas(activeCauseAreas);
+            setLoading(false);
+          }
+        })
+        .catch((err) => {
+          console.error("Error fetching data:", err);
+          setError("Failed to load cause areas");
+          setLoading(false);
+        });
+    }, []);
+
+    // Update the parent value when distributions change
+    useEffect(() => {
+      if (distributions !== props.value) {
+        props.onChange(PatchEvent.from(distributions.length ? set(distributions) : unset()));
+      }
+    }, [distributions]);
+
+    // Initialize from props
+    useEffect(() => {
+      if (props.value && props.value.length > 0) {
+        // Ensure all values have _key property
+        setDistributions(ensureKeys(props.value));
+      }
+    }, []);
+
+    // Get name for a cause area
+    const getCauseAreaName = (causeAreaId: number): string => {
+      const causeArea = allCauseAreas.find((area) => area.id === causeAreaId);
+      return causeArea ? causeArea.name : `Cause Area ${causeAreaId}`;
+    };
+
+    // Get name for an organization
+    const getOrganizationName = (orgId: number, causeAreaId: number): string => {
+      const causeArea = allCauseAreas.find((area) => area.id === causeAreaId);
+      if (!causeArea) return `Organization ${orgId}`;
+
+      const org = causeArea.organizations.find((org) => org.id === orgId);
+      return org ? org.widgetDisplayName || org.name : `Organization ${orgId}`;
+    };
+
+    // Add a cause area to the distribution
+    const addCauseArea = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const causeAreaId = parseInt(event.currentTarget.value, 10);
+      if (isNaN(causeAreaId)) return;
+
+      // Check if this cause area is already in the distribution
+      const existingIndex = distributions.findIndex(
+        (dist) => dist.type === "causeArea" && dist.id === causeAreaId,
+      );
+
+      if (existingIndex >= 0) {
+        // Cause area already exists, do nothing
+        return;
+      }
+
+      // Check if this is the first cause area being added
+      const existingCauseAreas = distributions.filter((dist) => dist.type === "causeArea");
+      const isFirstCauseArea = existingCauseAreas.length === 0;
+
+      // Add new cause area with a _key and default percentage (100% if first, 0% otherwise)
+      const newDistribution: DistributionItem = {
+        _key: generateKey(),
+        type: "causeArea",
+        id: causeAreaId,
+        percentage: isFirstCauseArea ? 100 : 0,
+        name: getCauseAreaName(causeAreaId),
+      };
+
+      setDistributions([...distributions, newDistribution]);
+
+      // Reset the select to default value
+      event.currentTarget.value = "";
+    };
+
+    // Add an organization to the distribution
+    const addOrganization = (causeAreaId: number, event: React.ChangeEvent<HTMLSelectElement>) => {
+      const orgId = parseInt(event.currentTarget.value, 10);
+      if (isNaN(orgId)) return;
+
+      // Check if this organization already exists
+      const existingIndex = distributions.findIndex(
+        (dist) =>
+          dist.type === "organization" && dist.id === orgId && dist.causeAreaId === causeAreaId,
+      );
+
+      if (existingIndex >= 0) {
+        // Organization already exists, do nothing
+        return;
+      }
+
+      // Check if this is the first organization for this cause area
+      const existingOrgsForCauseArea = distributions.filter(
+        (dist) => dist.type === "organization" && dist.causeAreaId === causeAreaId,
+      );
+      const isFirstOrganization = existingOrgsForCauseArea.length === 0;
+
+      // Add new organization with default percentage (100% if first, 0% otherwise)
+      const newDistribution: DistributionItem = {
+        _key: generateKey(),
+        type: "organization",
+        id: orgId,
+        causeAreaId: causeAreaId,
+        percentage: isFirstOrganization ? 100 : 0,
+        name: getOrganizationName(orgId, causeAreaId),
+      };
+
+      setDistributions([...distributions, newDistribution]);
+
+      // Reset the select to default value
+      event.currentTarget.value = "";
+    };
+
+    // Remove an item from the distribution
+    const removeDistribution = (key: string) => {
+      const itemToRemove = distributions.find((dist) => dist._key === key);
+
+      if (itemToRemove && itemToRemove.type === "causeArea") {
+        // If removing a cause area, also remove all organizations belonging to it
+        const newDistributions = distributions.filter(
+          (dist) =>
+            dist._key !== key &&
+            !(dist.type === "organization" && dist.causeAreaId === itemToRemove.id),
+        );
+        setDistributions(newDistributions);
+      } else {
+        // Just remove the single item
+        const newDistributions = distributions.filter((dist) => dist._key !== key);
+        setDistributions(newDistributions);
+      }
+    };
+
+    // Update item percentage
+    const updateItemPercentage = (key: string, newPercentage: number) => {
+      const validPercentage = isNaN(newPercentage) ? 0 : Math.min(100, Math.max(0, newPercentage));
+
+      const newDistributions = distributions.map((item) => {
+        if (item._key === key) {
+          return {
+            ...item,
+            percentage: validPercentage,
+          };
+        }
+        return item;
+      });
+
+      setDistributions(newDistributions);
+    };
+
+    // Calculate total percentages for validation
+    const calculateTotals = () => {
+      const causeAreaTotal = distributions
+        .filter((dist) => dist.type === "causeArea")
+        .reduce((sum, item) => sum + item.percentage, 0);
+
+      const orgTotals: Record<number, number> = {};
+
+      distributions
+        .filter((dist) => dist.type === "organization" && dist.causeAreaId)
+        .forEach((item) => {
+          const causeAreaId = item.causeAreaId as number;
+          orgTotals[causeAreaId] = (orgTotals[causeAreaId] || 0) + item.percentage;
+        });
+
+      return { causeAreaTotal, orgTotals };
+    };
+
+    // Group organizations by cause area
+    const getOrganizationsByCauseArea = (causeAreaId: number) => {
+      return distributions.filter(
+        (dist) => dist.type === "organization" && dist.causeAreaId === causeAreaId,
+      );
+    };
+
+    // Get available organizations for a cause area (not already added)
+    const getAvailableOrganizations = (causeAreaId: number) => {
+      const causeArea = causeAreas.find((area) => area.id === causeAreaId);
+      if (!causeArea) return [];
+
+      const activeOrgs = causeArea.organizations.filter((org) => org.isActive);
+
+      // Filter out organizations that are already in the distribution
+      const existingOrgIds = distributions
+        .filter((dist) => dist.type === "organization" && dist.causeAreaId === causeAreaId)
+        .map((dist) => dist.id);
+
+      return activeOrgs.filter((org) => !existingOrgIds.includes(org.id));
+    };
+
+    // Get available cause areas (not already added)
+    const getAvailableCauseAreas = () => {
+      const existingCauseAreaIds = distributions
+        .filter((dist) => dist.type === "causeArea")
+        .map((dist) => dist.id);
+
+      return causeAreas.filter((area) => !existingCauseAreaIds.includes(area.id));
+    };
+
+    const { causeAreaTotal, orgTotals } = calculateTotals();
+
+    // Get all cause areas in the distribution
+    const causeAreasInDistribution = distributions.filter((dist) => dist.type === "causeArea");
+
+    if (loading) return <Text>Loading data...</Text>;
+    if (error) return <Text>{error}</Text>;
+
+    return (
+      <div ref={ref}>
+        <Stack space={4}>
+          {/* Distribution Overview - Cause Areas and their Organizations */}
+
+          {distributions.length === 0 ? (
+            <></>
+          ) : (
+            <Stack space={3}>
+              {causeAreaTotal !== 100 && distributions.some((d) => d.type === "causeArea") && (
+                <Text size={1} tone="caution">
+                  Cause area percentages should sum to 100%. Current total: {causeAreaTotal}%
+                </Text>
+              )}
+
+              {causeAreasInDistribution.map((causeAreaItem) => (
+                <Card key={causeAreaItem._key} padding={3} radius={2} tone="default" border>
+                  <Stack space={3}>
+                    {/* Cause Area Header */}
+                    <Card padding={2} radius={2} tone="primary">
+                      <Flex align="center">
+                        <Box flex={1}>
+                          <Text weight="semibold">
+                            {causeAreaItem.name || `Cause Area ${causeAreaItem.id}`}
+                          </Text>
+                        </Box>
+
+                        <Flex align="center" gap={2}>
+                          <Label htmlFor={`ca-pct-${causeAreaItem._key}`} style={{ margin: 0 }}>
+                            Percentage:
+                          </Label>
+                          <TextInput
+                            id={`ca-pct-${causeAreaItem._key}`}
+                            type="number"
+                            value={causeAreaItem.percentage.toString()}
+                            onChange={(e) =>
+                              updateItemPercentage(
+                                causeAreaItem._key,
+                                parseInt(e.currentTarget.value, 10),
+                              )
+                            }
+                            min={0}
+                            max={100}
+                            style={{ width: "80px" }}
+                          />
+                          <Button
+                            icon={TrashIcon}
+                            onClick={() => removeDistribution(causeAreaItem._key)}
+                            tone="critical"
+                            mode="ghost"
+                          />
+                        </Flex>
+                      </Flex>
+                    </Card>
+
+                    {/* Organizations within this Cause Area */}
+                    <Stack space={2}>
+                      <Text size={1} weight="semibold">
+                        Organizations:
+                      </Text>
+
+                      {getOrganizationsByCauseArea(causeAreaItem.id).length === 0 ? (
+                        <></>
+                      ) : (
+                        getOrganizationsByCauseArea(causeAreaItem.id).map((orgItem) => (
+                          <Card key={orgItem._key} padding={2} radius={2} border tone="default">
+                            <Flex align="center">
+                              <Box flex={1}>
+                                <Text>{orgItem.name || `Organization ${orgItem.id}`}</Text>
+                              </Box>
+
+                              <Flex align="center" gap={2}>
+                                <Label htmlFor={`org-pct-${orgItem._key}`} style={{ margin: 0 }}>
+                                  Percentage:
+                                </Label>
+                                <TextInput
+                                  id={`org-pct-${orgItem._key}`}
+                                  type="number"
+                                  value={orgItem.percentage.toString()}
+                                  onChange={(e) =>
+                                    updateItemPercentage(
+                                      orgItem._key,
+                                      parseInt(e.currentTarget.value, 10),
+                                    )
+                                  }
+                                  min={0}
+                                  max={100}
+                                  style={{ width: "80px" }}
+                                />
+                                <Button
+                                  icon={TrashIcon}
+                                  onClick={() => removeDistribution(orgItem._key)}
+                                  tone="critical"
+                                  mode="ghost"
+                                />
+                              </Flex>
+                            </Flex>
+                          </Card>
+                        ))
+                      )}
+
+                      {/* Show organization total percentage */}
+                      {causeAreaItem.id in orgTotals && orgTotals[causeAreaItem.id] != 100 && (
+                        <Text
+                          size={1}
+                          tone={orgTotals[causeAreaItem.id] === 100 ? "positive" : "caution"}
+                        >
+                          Organizations total: {orgTotals[causeAreaItem.id]}%
+                        </Text>
+                      )}
+                    </Stack>
+
+                    {/* Add new organization */}
+                    <Card padding={2} radius={2} border tone="default">
+                      <Flex align="center">
+                        <Box flex={1}>
+                          <Label htmlFor={`add-org-${causeAreaItem.id}`}>Add Organization</Label>
+                        </Box>
+                        <Box flex={1}>
+                          <Select
+                            id={`add-org-${causeAreaItem.id}`}
+                            onChange={(e) => addOrganization(causeAreaItem.id, e)}
+                            value=""
+                          >
+                            <option value="">Select an organization</option>
+                            {getAvailableOrganizations(causeAreaItem.id).map((org) => (
+                              <option key={org.id} value={org.id.toString()}>
+                                {org.widgetDisplayName || org.name}
+                              </option>
+                            ))}
+                          </Select>
+                        </Box>
+                      </Flex>
+                    </Card>
+                  </Stack>
+                </Card>
+              ))}
+            </Stack>
+          )}
+
+          {/* Add new cause area */}
+          {getAvailableCauseAreas().length > 0 && (
+            <Card padding={3} radius={2} tone="default" border>
+              <Stack space={3}>
+                <Flex align="center">
+                  <Box flex={1}>
+                    <Label htmlFor="new-cause-area">Add Cause Area</Label>
+                  </Box>
+                  <Box flex={1}>
+                    <Select id="new-cause-area" onChange={addCauseArea} value="">
+                      <option value="">Select a cause area</option>
+                      {getAvailableCauseAreas().map((area) => (
+                        <option key={area.id} value={area.id.toString()}>
+                          {area.name}
+                        </option>
+                      ))}
+                    </Select>
+                  </Box>
+                </Flex>
+              </Stack>
+            </Card>
+          )}
+        </Stack>
+      </div>
+    );
+  },
+);

--- a/studio/components/distributionInput.tsx
+++ b/studio/components/distributionInput.tsx
@@ -55,6 +55,8 @@ const ensureKeys = (items: any[]): DistributionItem[] => {
   });
 };
 
+const api = process.env.SANITY_STUDIO_EFFEKT_API_URL;
+
 // DistributionInput Component (main input component for Sanity)
 export const DistributionInput = React.forwardRef<HTMLDivElement, DistributionInputProps>(
   (props, ref) => {
@@ -70,7 +72,7 @@ export const DistributionInput = React.forwardRef<HTMLDivElement, DistributionIn
     // Fetch all cause areas and organizations for displaying names
     useEffect(() => {
       setLoading(true);
-      fetch("http://localhost:5050/causeareas/all")
+      fetch(`${api}/causeareas/all`)
         .then((response) => response.json())
         .then((data) => {
           if (data && data.content) {
@@ -152,7 +154,7 @@ export const DistributionInput = React.forwardRef<HTMLDivElement, DistributionIn
     };
 
     // Add an organization to the distribution
-    const addOrganization = (causeAreaId: number, event: React.ChangeEvent<HTMLSelectElement>) => {
+    const addOrganization = (causeAreaId: number, event: React.FormEvent<HTMLSelectElement>) => {
       const orgId = parseInt(event.currentTarget.value, 10);
       if (isNaN(orgId)) return;
 
@@ -292,7 +294,7 @@ export const DistributionInput = React.forwardRef<HTMLDivElement, DistributionIn
           ) : (
             <Stack space={3}>
               {causeAreaTotal !== 100 && distributions.some((d) => d.type === "causeArea") && (
-                <Text size={1} tone="caution">
+                <Text size={1}>
                   Cause area percentages should sum to 100%. Current total: {causeAreaTotal}%
                 </Text>
               )}
@@ -385,12 +387,7 @@ export const DistributionInput = React.forwardRef<HTMLDivElement, DistributionIn
 
                       {/* Show organization total percentage */}
                       {causeAreaItem.id in orgTotals && orgTotals[causeAreaItem.id] != 100 && (
-                        <Text
-                          size={1}
-                          tone={orgTotals[causeAreaItem.id] === 100 ? "positive" : "caution"}
-                        >
-                          Organizations total: {orgTotals[causeAreaItem.id]}%
-                        </Text>
+                        <Text size={1}>Organizations total: {orgTotals[causeAreaItem.id]}%</Text>
                       )}
                     </Stack>
 

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -85,6 +85,7 @@ import generalbanner from "./types/generalbanner";
 import teamintroduction from "./types/teamintroduction";
 import resultsteaser from "./types/resultsteaser";
 import taxdeductionwidget from "./types/taxdeductionwidget";
+import donationwidgetblock from "./types/donationwidgetblock";
 
 const paymentMethods = [vipps, bank, swish, autogiro, avtalegiro] as const;
 
@@ -167,7 +168,7 @@ export const types = [
   plausiblerevenuetracker,
   teasers,
   teasersitem,
-  donation_widget_block,
+  donationwidgetblock,
 ] as const;
 
 // Then we give our schema to the builder and provide the result to Sanity

--- a/studio/schemas/schema.ts
+++ b/studio/schemas/schema.ts
@@ -167,6 +167,7 @@ export const types = [
   plausiblerevenuetracker,
   teasers,
   teasersitem,
+  donation_widget_block,
 ] as const;
 
 // Then we give our schema to the builder and provide the result to Sanity

--- a/studio/schemas/types/contentsection.ts
+++ b/studio/schemas/types/contentsection.ts
@@ -89,7 +89,7 @@ export default {
         { type: "itncoverage" },
         { type: "fundraiserchart" },
         { type: "plausiblerevenuetracker" },
-        { type: "donation_widget_block" },
+        { type: "donationwidgetblock" },
       ],
       options: {
         modal: "fullscreen",

--- a/studio/schemas/types/contentsection.ts
+++ b/studio/schemas/types/contentsection.ts
@@ -89,6 +89,7 @@ export default {
         { type: "itncoverage" },
         { type: "fundraiserchart" },
         { type: "plausiblerevenuetracker" },
+        { type: "donation_widget_block" },
       ],
       options: {
         modal: "fullscreen",

--- a/studio/schemas/types/donationwidget.ts
+++ b/studio/schemas/types/donationwidget.ts
@@ -1,5 +1,3 @@
-import { group } from "console";
-
 export default {
   name: "donationwidget",
   type: "document",
@@ -53,6 +51,16 @@ export default {
       name: "monthly_donation_text",
       title: "Monthly donation option text",
       type: "string",
+      group: "pane1",
+      validation: (Rule: any) => Rule.required(),
+    },
+    {
+      name: "default_donation_type",
+      title: "Default donation type",
+      type: "string",
+      options: {
+        list: ["single", "monthly"],
+      },
       group: "pane1",
       validation: (Rule: any) => Rule.required(),
     },

--- a/studio/schemas/types/donationwidget.ts
+++ b/studio/schemas/types/donationwidget.ts
@@ -343,24 +343,6 @@ export default {
       group: "referrals",
       validation: (Rule: any) => Rule.required(),
     },
-    // New schema for donation widget block
-    {
-      name: "donation_widget_block",
-      title: "Donation Widget Block",
-      type: "object",
-      fields: [
-        {
-          name: "title",
-          title: "Title",
-          type: "string",
-        },
-        {
-          name: "description",
-          title: "Description",
-          type: "text",
-        },
-      ],
-    },
   ],
   preview: {
     prepare() {

--- a/studio/schemas/types/donationwidget.ts
+++ b/studio/schemas/types/donationwidget.ts
@@ -343,6 +343,24 @@ export default {
       group: "referrals",
       validation: (Rule: any) => Rule.required(),
     },
+    // New schema for donation widget block
+    {
+      name: "donation_widget_block",
+      title: "Donation Widget Block",
+      type: "object",
+      fields: [
+        {
+          name: "title",
+          title: "Title",
+          type: "string",
+        },
+        {
+          name: "description",
+          title: "Description",
+          type: "text",
+        },
+      ],
+    },
   ],
   preview: {
     prepare() {

--- a/studio/schemas/types/donationwidgetblock.ts
+++ b/studio/schemas/types/donationwidgetblock.ts
@@ -1,3 +1,4 @@
+import { DollarSign } from "react-feather";
 import { DistributionInput } from "../../components/distributionInput";
 import { blocktype } from "./blockcontent";
 
@@ -5,6 +6,7 @@ export default {
   name: "donationwidgetblock",
   type: "document",
   title: "Donation widget block",
+  icon: DollarSign,
   fields: [
     {
       name: "content",
@@ -62,75 +64,7 @@ export default {
             list: ["single", "recurring"],
           },
         },
-        {
-          name: "amount_context",
-          title: "Donation amount inputs context",
-          type: "object",
-          description: "Preset amounts are only used if there is only one cause area",
-          fields: [
-            {
-              name: "preset_amounts_recurring",
-              title: "Preset amounts for recurring donations",
-              type: "array",
-              of: [
-                {
-                  type: "object",
-                  fields: [
-                    {
-                      title: "Value",
-                      name: "amount",
-                      type: "number",
-                    },
-                    {
-                      title: "Subtext",
-                      name: "subtext",
-                      type: "string",
-                    },
-                  ],
-                  preview: {
-                    select: {
-                      title: "amount",
-                      subtitle: "subtext",
-                    },
-                  },
-                },
-              ],
-            },
-            {
-              name: "preset_amounts_single",
-              title: "Preset amounts for single donations",
-              type: "array",
-              of: [
-                {
-                  type: "object",
-                  fields: [
-                    {
-                      title: "Value",
-                      name: "amount",
-                      type: "number",
-                    },
-                    {
-                      title: "Subtext",
-                      name: "subtext",
-                      type: "string",
-                    },
-                  ],
-                  preview: {
-                    select: {
-                      title: "amount",
-                      subtitle: "subtext",
-                    },
-                  },
-                },
-              ],
-            },
-          ],
-        },
-        {
-          name: "prefilled_sum",
-          title: "Prefilled amount",
-          type: "number",
-        },
+        // Can add more properties from the donation widget configuration here later
         {
           name: "prefilled_distribution",
           type: "array",
@@ -155,4 +89,12 @@ export default {
       ],
     },
   ],
+  preview: {
+    prepare: () => ({
+      title: "Inline donation widget",
+    }),
+    select: {
+      title: "title",
+    },
+  },
 };

--- a/studio/schemas/types/donationwidgetblock.ts
+++ b/studio/schemas/types/donationwidgetblock.ts
@@ -59,7 +59,7 @@ export default {
           title: "Default donation type",
           type: "string",
           options: {
-            list: ["single", "monthly"],
+            list: ["single", "recurring"],
           },
         },
         {

--- a/studio/schemas/types/donationwidgetblock.ts
+++ b/studio/schemas/types/donationwidgetblock.ts
@@ -1,23 +1,158 @@
+import { DistributionInput } from "../../components/distributionInput";
+import { blocktype } from "./blockcontent";
+
 export default {
   name: "donationwidgetblock",
   type: "document",
   title: "Donation widget block",
   fields: [
     {
-      name: "title",
-      type: "string",
-      title: "Title",
+      name: "content",
+      type: "array",
+      title: "Content",
+      description: "Optional content to display side by side with the donation widget",
+      of: [
+        {
+          ...blocktype,
+          marks: {
+            ...blocktype.marks,
+            annotations: blocktype.marks.annotations.filter(
+              (annotation) => annotation.name !== "citation",
+            ),
+          },
+        },
+      ],
     },
     {
-      name: "description",
-      type: "text",
-      title: "Description",
+      name: "content_position",
+      type: "string",
+      title: "Content position",
+      options: {
+        list: ["left", "right"],
+      },
+      hidden: ({ parent }) => !parent?.content || parent.content.length === 0,
+    },
+    {
+      name: "content_mobile_position",
+      type: "string",
+      title: "Content mobile position",
+      options: {
+        list: ["top", "bottom"],
+      },
+      hidden: ({ parent }) => !parent?.content || parent.content.length === 0,
     },
     {
       name: "donationwidget",
       type: "reference",
       title: "Donation widget configuration",
       to: [{ type: "donationwidget" }],
+    },
+    {
+      name: "overrides",
+      type: "object",
+      title: "Overrides",
+      description:
+        "Override the settings from the donation widget configuration for this inline widget, non-overridden settings will be inherited from the donation widget configuration",
+      fields: [
+        {
+          name: "default_donation_type",
+          title: "Default donation type",
+          type: "string",
+          options: {
+            list: ["single", "monthly"],
+          },
+        },
+        {
+          name: "amount_context",
+          title: "Donation amount inputs context",
+          type: "object",
+          description: "Preset amounts are only used if there is only one cause area",
+          fields: [
+            {
+              name: "preset_amounts_recurring",
+              title: "Preset amounts for recurring donations",
+              type: "array",
+              of: [
+                {
+                  type: "object",
+                  fields: [
+                    {
+                      title: "Value",
+                      name: "amount",
+                      type: "number",
+                    },
+                    {
+                      title: "Subtext",
+                      name: "subtext",
+                      type: "string",
+                    },
+                  ],
+                  preview: {
+                    select: {
+                      title: "amount",
+                      subtitle: "subtext",
+                    },
+                  },
+                },
+              ],
+            },
+            {
+              name: "preset_amounts_single",
+              title: "Preset amounts for single donations",
+              type: "array",
+              of: [
+                {
+                  type: "object",
+                  fields: [
+                    {
+                      title: "Value",
+                      name: "amount",
+                      type: "number",
+                    },
+                    {
+                      title: "Subtext",
+                      name: "subtext",
+                      type: "string",
+                    },
+                  ],
+                  preview: {
+                    select: {
+                      title: "amount",
+                      subtitle: "subtext",
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        {
+          name: "prefilled_sum",
+          title: "Prefilled amount",
+          type: "number",
+        },
+        {
+          name: "prefilled_distribution",
+          type: "array",
+          title: "Prefilled distribution",
+          // This won't actually be used since we have a custom input component
+          of: [
+            {
+              type: "object",
+              fields: [
+                { name: "type", type: "string" },
+                { name: "id", type: "number" },
+                { name: "causeAreaId", type: "number" },
+                { name: "percentage", type: "number" },
+                { name: "name", type: "string" },
+              ],
+            },
+          ],
+          components: {
+            input: DistributionInput,
+          },
+        },
+      ],
     },
   ],
 };

--- a/studio/schemas/types/donationwidgetblock.ts
+++ b/studio/schemas/types/donationwidgetblock.ts
@@ -1,0 +1,23 @@
+export default {
+  name: "donationwidgetblock",
+  type: "document",
+  title: "Donation widget block",
+  fields: [
+    {
+      name: "title",
+      type: "string",
+      title: "Title",
+    },
+    {
+      name: "description",
+      type: "text",
+      title: "Description",
+    },
+    {
+      name: "donationwidget",
+      type: "reference",
+      title: "Donation widget configuration",
+      to: [{ type: "donationwidget" }],
+    },
+  ],
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -142,7 +142,7 @@ button {
   flex-direction: column;
 }
 
-#widget {
+.widget {
   display: grid;
   grid-template-rows: max-content max-content;
   width: 576px;
@@ -150,12 +150,12 @@ button {
   overflow-y: auto;
 }
 
-#widget::-webkit-scrollbar {
+.widget::-webkit-scrollbar {
   width: 0px;
   background: transparent;
 }
 
-#carousel-wrapper {
+.carousel-wrapper {
   display: flex;
   flex-grow: 1;
   flex-direction: column;
@@ -164,7 +164,7 @@ button {
   overflow-y: visible;
 }
 
-#carousel {
+.carousel {
   white-space: nowrap;
   transition: all 200ms;
   height: 100%;


### PR DESCRIPTION
Add the donation widget as a reusable sanity component for inline embedding on any page.

* **Widget Component Changes**
  - Add a new `inline` prop to the `Widget` component in `components/shared/components/Widget/components/Widget.tsx`.
  - Update the `useWidgetScaleEffect` function to conditionally apply resizing logic based on the `inline` prop.
  - Modify the `Widget` component to handle local state management when `inline` is true.

* **Block Content Renderer Changes**
  - Import the `Widget` component in `components/main/blocks/BlockContentRenderer.tsx`.
  - Add a new case in the `SectionBlockContentRenderer` switch statement to render the `Widget` component with the `inline` prop.

* **Sanity Schema Changes**
  - Add a new schema for the donation widget block in `studio/schemas/types/donationwidget.ts`.
  - Define the fields for the donation widget block schema.
  - Add `donation_widget_block` as an option in the content section in `studio/schemas/types/contentsection.ts`.
  - Add `donation_widget_block` to the schema file in `studio/schemas/schema.ts`.

