### PR TITLE
Statically fetch data from impact API for intervention costs

### DIFF
--- a/_queries.ts
+++ b/_queries.ts
@@ -370,6 +370,28 @@ export const questionAndAnswerSelectionQuery = `
     ${linksContentQuery}
 } `;
 
+const interventionOutputConfigurationQueery = `
+  ...,
+  output_configuration->{
+    ...,
+    "interventions": interventions[] {
+      ...,
+      "organization": organization->{
+        _type,
+        intervention,
+        database_ids,
+      }
+    },
+    "donate_label_short": *[ _type == "site_settings"][0].donate_label_short,
+    "locale": *[ _type == "site_settings"][0].main_locale,
+    explanation_links[] {
+      ${linksSelectorQuery}
+    },
+  },
+  "currency": *[ _type == "site_settings"][0].main_currency,
+  "locale": *[ _type == "site_settings"][0].main_locale,
+`;
+
 export const pageContentQuery = `content[hidden!=true] {
   ...,
   blocks[] {
@@ -401,7 +423,12 @@ export const pageContentQuery = `content[hidden!=true] {
     },
     _type == 'opendistributionbutton' =>  {
       ...,
-      organization->,
+      organization->{
+        _type,
+        intervention,
+        database_ids,
+        ...,
+      }
     },
     _type == 'fullvideo' =>  {
       ...,
@@ -480,17 +507,7 @@ export const pageContentQuery = `content[hidden!=true] {
         },
       },
       intervention_configuration {
-        ...,
-        output_configuration->{
-          ...,
-          "donate_label_short": *[ _type == "site_settings"][0].donate_label_short,
-          "locale": *[ _type == "site_settings"][0].main_locale,
-          explanation_links[] {
-            ${linksSelectorQuery}
-          },
-        },
-        "currency": *[ _type == "site_settings"][0].main_currency,
-        "locale": *[ _type == "site_settings"][0].main_locale,
+        ${interventionOutputConfigurationQueery}
       },
       "currency": *[ _type == "site_settings"][0].main_currency,
       "locale": *[ _type == "site_settings"][0].main_locale,
@@ -524,17 +541,7 @@ export const pageContentQuery = `content[hidden!=true] {
       "locale": *[ _type == "site_settings"][0].main_locale,
     },
     _type == 'interventionwidget' => {
-      ...,
-      output_configuration->{
-        ...,
-        "donate_label_short": *[ _type == "site_settings"][0].donate_label_short,
-        "locale": *[ _type == "site_settings"][0].main_locale,
-        explanation_links[] {
-          ${linksSelectorQuery}
-        },
-      },
-      "currency": *[ _type == "site_settings"][0].main_currency,
-      "locale": *[ _type == "site_settings"][0].main_locale,
+      ${interventionOutputConfigurationQueery}
     },
     _type == 'giftcardteaser' => {
       ...,

--- a/_queries.ts
+++ b/_queries.ts
@@ -427,7 +427,6 @@ export const pageContentQuery = `content[hidden!=true] {
         _type,
         intervention,
         database_ids,
-        ...,
       }
     },
     _type == 'fullvideo' =>  {

--- a/components/main/blocks/BlockContentRenderer.tsx
+++ b/components/main/blocks/BlockContentRenderer.tsx
@@ -36,15 +36,15 @@ import { PhilantropicTeaser } from "./PhilantropicTeaser/PhilantropicTeaser";
 import { stegaClean } from "@sanity/client/stega";
 import dynamic from "next/dynamic";
 import { PlausibleRevenueTracker } from "./PlausibleRevenueTracker/PlausibleRevenueTracker";
-import { OpenDistributionButton } from "./OpenDistributionButton/OpenDistributionButton";
-import { Fundraiserchart, Opendistributionbutton } from "../../../studio/sanity.types";
+import {
+  OpenDistributionButton,
+  OpenDistributionButtonProps,
+} from "./OpenDistributionButton/OpenDistributionButton";
+import { Fundraiserchart } from "../../../studio/sanity.types";
 import { FundraiserChart } from "./FundraiserChart/FundraiserChart";
 import { TeamIntroduction } from "./TeamIntroduction/TeamIntroduction";
 import { ResultsTeaser } from "./ResultsTeaser/ResultsTeaser";
 import { TaxDeductionWidget } from "./TaxDeductionWidget/TaxDeductionWidget";
-import { Widget } from "../../shared/components/Widget/components/Widget";
-import { WidgetWithStore } from "../../shared/components/Widget/components/WidgetWithStore";
-import { PrefilledDistribution } from "../layout/WidgetPane/WidgetPane";
 import { DonationWidgetBlock } from "./DonationWidgetBlock/DonationWidgetBlock";
 
 /* Dynamic imports */
@@ -382,7 +382,7 @@ export const SectionBlockContentRenderer: React.FC<{ blocks: any }> = ({ blocks 
             return (
               <OpenDistributionButton
                 key={block._key || block._id}
-                {...(block as Opendistributionbutton)}
+                {...(block as OpenDistributionButtonProps)}
               />
             );
           }

--- a/components/main/blocks/InterventionWidget/InterventionWidgetOutput.tsx
+++ b/components/main/blocks/InterventionWidget/InterventionWidgetOutput.tsx
@@ -64,12 +64,9 @@ export const InterventionWidgetOutput: React.FC<{
     );
   }, [selectedIntervention]);
 
-  if (!currentIntervention) {
-    return "No current intervention";
-  }
-
   const outputString = useMemo(() => {
     if (
+      !currentIntervention ||
       !currentIntervention.organization.impact_estimate ||
       !currentIntervention.organization.impact_estimate.evaluation ||
       !currentIntervention.organization.intervention
@@ -106,6 +103,10 @@ export const InterventionWidgetOutput: React.FC<{
     }
     return "-";
   }, [currentIntervention, sum]);
+
+  if (!currentIntervention) {
+    return "No current intervention";
+  }
 
   return (
     <div className={styles.wrapper}>

--- a/components/main/blocks/InterventionWidget/InterventionWidgetOutput.tsx
+++ b/components/main/blocks/InterventionWidget/InterventionWidgetOutput.tsx
@@ -1,8 +1,7 @@
-import React, { useContext, useEffect, useMemo, useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
 import AnimateHeight from "react-animate-height";
 import styles from "./InterventionWidget.module.scss";
 import { LinkType, Links } from "../Links/Links";
-import { Spinner } from "../../../shared/components/Spinner/Spinner";
 import { thousandize } from "../../../../util/formatting";
 import { PortableText } from "@portabletext/react";
 import { NavLink } from "../../../shared/components/Navbar/Navbar";
@@ -10,6 +9,7 @@ import { stegaClean } from "@sanity/client/stega";
 import { EffektButton } from "../../../shared/components/EffektButton/EffektButton";
 import { WidgetContext } from "../../layout/layout";
 import { usePlausible } from "next-plausible";
+import { ImpactEvaluation } from "../../../../models";
 
 export type InterventionWidgetOutputConfiguration = {
   interventions: SanityIntervention[];
@@ -23,22 +23,22 @@ export type InterventionWidgetOutputConfiguration = {
 
 export type SanityIntervention = {
   title: string;
-  organization_name: string;
-  abbreviation: string;
+  organization: {
+    database_ids: {
+      cause_area_id: number;
+      organization_id: number;
+    };
+    intervention: {
+      abbreviation: string;
+      type: string;
+      scaling_factor: number;
+    };
+    impact_estimate: {
+      evaluation: ImpactEvaluation;
+    } | null;
+  };
   template_string: string;
-  organization_id: number;
-  cause_area_id: number;
-};
-
-type Intervention = {
-  title: string;
-  organizationName: string;
-  abbreviation: string;
-  pricePerOutput?: number;
-  outputStringTemplate: string;
-  organizationId: number;
-  causeAreaId: number;
-  shortDescription: string;
+  template_donate_button: string;
 };
 
 export const InterventionWidgetOutput: React.FC<{
@@ -50,181 +50,144 @@ export const InterventionWidgetOutput: React.FC<{
   const { interventions, explanation_label, explanation_text, explanation_links } = configuration;
 
   const [contextExpanded, setContextExpanded] = useState(false);
-  const [interventionCosts, setInterventionCosts] = useState<Map<string, number>>(new Map());
-  const [interventionShortDescriptions, setInterventionShortDescriptions] = useState<
-    Map<string, string>
-  >(new Map());
-  const [selectedIntervention, setSelectedIntervention] = useState<string>(
-    interventions ? interventions[0].title : "",
+
+  const [selectedIntervention, setSelectedIntervention] = useState<number>(
+    interventions[0].organization.database_ids.organization_id,
   );
   const [widgetContext, setWidgetContext] = useContext(WidgetContext);
   const plausible = usePlausible();
-  const currentDate = useMemo(() => new Date(), []);
 
-  useEffect(() => {
-    if (interventions && interventions.length > 0) {
-      const url = `https://impact.gieffektivt.no/api/evaluations?${interventions
-        .map((i: any) => `charity_abbreviation=${stegaClean(i.abbreviation)}&`)
-        .join("")}currency=${stegaClean(currency)}&language=${stegaClean(
-        configuration.locale,
-      )}&conversion_year=${currentDate.getFullYear()}&conversion_month=${
-        currentDate.getMonth() + 1
-      }`;
-      fetch(url)
-        .then((res) => {
-          res.json().then((data) => {
-            const costs = new Map();
-            const shortDescriptions = new Map();
-            const evaluations = data.evaluations;
-            interventions.forEach((i: SanityIntervention) => {
-              // For each intervention, filter the evaluations for a given charity
-              const filtered = evaluations.filter(
-                (e: any) => e.charity.abbreviation === stegaClean(i.abbreviation),
-              );
-              // Then order the list to get the most recent
-              const ordered = filtered.sort((a: any, b: any) => b.start_year - a.start_year);
-              // Get the most recent evaluation
-              const evaluation = ordered[0];
-              // Set the cost to the most recent evaluation converted cost (cost in NOK per output)
-              costs.set(stegaClean(i.abbreviation), evaluation.converted_cost_per_output);
-              shortDescriptions.set(
-                stegaClean(i.abbreviation),
-                evaluation.intervention.short_description,
-              );
-            });
-            setInterventionCosts(costs);
-            setInterventionShortDescriptions(shortDescriptions);
-          });
-        })
-        .catch((err) => {
-          console.error(err);
-        });
-    }
-  }, [interventions]);
-
-  if (typeof interventions === "undefined" || interventions.length === 0) {
-    return <span>No internventions</span>;
-  }
-
-  const mappedInterventions: Intervention[] = interventions.map((i: SanityIntervention) => ({
-    title: i.title,
-    abbreviation: i.abbreviation,
-    pricePerOutput: interventionCosts.get(stegaClean(i.abbreviation)),
-    outputStringTemplate: i.template_string,
-    organizationName: i.organization_name,
-    organizationId: i.organization_id,
-    causeAreaId: i.cause_area_id,
-    shortDescription: interventionShortDescriptions.get(stegaClean(i.abbreviation)) || "",
-  }));
-
-  const currentIntervention = mappedInterventions.find(
-    (i: any) => stegaClean(i.title) === selectedIntervention,
-  ) as Intervention;
+  const currentIntervention = useMemo(() => {
+    return interventions.find(
+      (i: SanityIntervention) =>
+        stegaClean(i.organization.database_ids.organization_id) === selectedIntervention,
+    );
+  }, [selectedIntervention]);
 
   if (!currentIntervention) {
-    setSelectedIntervention(stegaClean(mappedInterventions[0].title));
-    return <Spinner />;
+    return "No current intervention";
   }
 
-  const output = currentIntervention.pricePerOutput
-    ? Math.round(sum / currentIntervention.pricePerOutput)
-    : 0;
-  const loading = typeof currentIntervention.pricePerOutput === "undefined";
-  let outputString;
-  if (isNaN(output)) {
-    outputString = "0";
-  } else {
-    outputString = output.toString();
-  }
+  const outputString = useMemo(() => {
+    if (
+      !currentIntervention.organization.impact_estimate ||
+      !currentIntervention.organization.impact_estimate.evaluation ||
+      !currentIntervention.organization.intervention
+    ) {
+      return "-";
+    }
+    if (currentIntervention.organization.intervention.type === "output") {
+      return thousandize(
+        Math.round(
+          sum /
+            currentIntervention.organization.impact_estimate.evaluation.converted_cost_per_output,
+        ),
+      );
+    }
+    if (currentIntervention.organization.intervention.type === "percentage") {
+      return `${thousandize(
+        Math.round(
+          (100 / currentIntervention.organization.impact_estimate.evaluation.cents_per_output) *
+            sum,
+        ),
+      )}`;
+    }
+    if (currentIntervention.organization.intervention.type === "scaled_output") {
+      if (currentIntervention.organization.intervention.scaling_factor) {
+        return thousandize(
+          Math.round(
+            sum /
+              (currentIntervention.organization.impact_estimate.evaluation
+                .converted_cost_per_output *
+                currentIntervention.organization.intervention.scaling_factor),
+          ),
+        );
+      }
+    }
+    return "-";
+  }, [currentIntervention, sum]);
 
   return (
     <div className={styles.wrapper}>
       <div className={styles.select}>
-        {interventions.map((i: any) => (
+        {interventions.map((i: SanityIntervention) => (
           <button
             data-cy={`${i.title}-button`}
             key={i.title}
             onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
               e.currentTarget.blur();
-              setSelectedIntervention(stegaClean(i.title));
+              setSelectedIntervention(stegaClean(i.organization.database_ids.organization_id));
             }}
-            className={stegaClean(i.title) === selectedIntervention ? styles.selected : ""}
+            className={
+              stegaClean(i.organization.database_ids.organization_id) === selectedIntervention
+                ? styles.selected
+                : ""
+            }
           >
             {i.title}
           </button>
         ))}
       </div>
       <div className={styles.output}>
-        {loading && (
-          <div className={styles.spinnerWrapper}>
-            <Spinner />
+        <div className={styles.paragraphWrapper}>
+          <span data-cy="impact-output" className={styles.paragraphNumber}>
+            {outputString}
+          </span>
+          <div className={styles.explanatory}>
+            <p>
+              <span className={styles.innerParagraphNumber}>{outputString}</span>
+              {currentIntervention.template_string}
+            </p>
+            <span
+              className={contextExpanded ? styles.captionopen : ""}
+              onClick={() => setContextExpanded(!contextExpanded)}
+            >
+              {explanation_label}&nbsp;&nbsp;
+            </span>
           </div>
-        )}
-        {!loading && (
-          <>
-            <span className="detailheader">{currentIntervention.organizationName}</span>
-            <div className={styles.paragraphWrapper}>
-              <span data-cy="impact-output" className={styles.paragraphNumber}>
-                {thousandize(parseInt(outputString))}
-              </span>
-              <div className={styles.explanatory}>
-                <p>
-                  <span className={styles.innerParagraphNumber}>{outputString}</span>
-                  {currentIntervention.outputStringTemplate}
-                </p>
-                <span
-                  className={contextExpanded ? styles.captionopen : ""}
-                  onClick={() => setContextExpanded(!contextExpanded)}
-                >
-                  {explanation_label}&nbsp;&nbsp;
-                </span>
-              </div>
-            </div>
-            <AnimateHeight duration={300} height={contextExpanded ? "auto" : 0} animateOpacity>
-              <div className={styles.context}>
-                <PortableText value={explanation_text} />
-              </div>
-              {explanation_links && <Links links={explanation_links}></Links>}
-            </AnimateHeight>
-            {configuration.donate_button && (
-              <div className={styles.giveButtonWrapper}>
-                <EffektButton
-                  onClick={() => {
-                    plausible("OpenDonationWidget", {
-                      props: {
-                        page: window.location.pathname,
-                      },
-                    });
-                    plausible("OpenDonationWidgetInterventionWidgetCTA", {
-                      props: {
-                        page: window.location.pathname,
-                      },
-                    });
-                    setWidgetContext({
-                      open: true,
-                      prefilled: [
+        </div>
+        <AnimateHeight duration={300} height={contextExpanded ? "auto" : 0} animateOpacity>
+          <div className={styles.context}>
+            <PortableText value={explanation_text} />
+          </div>
+          {explanation_links && <Links links={explanation_links}></Links>}
+        </AnimateHeight>
+        {configuration.donate_button && (
+          <div className={styles.giveButtonWrapper}>
+            <EffektButton
+              onClick={() => {
+                plausible("OpenDonationWidget", {
+                  props: {
+                    page: window.location.pathname,
+                  },
+                });
+                plausible("OpenDonationWidgetInterventionWidgetCTA", {
+                  props: {
+                    page: window.location.pathname,
+                  },
+                });
+                setWidgetContext({
+                  open: true,
+                  prefilled: [
+                    {
+                      causeAreaId: currentIntervention.organization.database_ids.cause_area_id,
+                      share: 100,
+                      organizations: [
                         {
-                          causeAreaId: currentIntervention.causeAreaId,
+                          organizationId:
+                            currentIntervention.organization.database_ids.organization_id,
                           share: 100,
-                          organizations: [
-                            {
-                              organizationId: currentIntervention.organizationId,
-                              share: 100,
-                            },
-                          ],
                         },
                       ],
-                      prefilledSum: sum,
-                    });
-                  }}
-                >
-                  {configuration.donate_label_short?.replace(".", "") || "Gi"}{" "}
-                  {thousandize(parseInt(outputString))}{" "}
-                  {currentIntervention.shortDescription.toLowerCase()}
-                </EffektButton>
-              </div>
-            )}
-          </>
+                    },
+                  ],
+                  prefilledSum: sum,
+                });
+              }}
+            >
+              {currentIntervention.template_donate_button.replace("{outputs}", outputString)}
+            </EffektButton>
+          </div>
         )}
       </div>
     </div>

--- a/components/main/blocks/OpenDistributionButton/OpenDistributionButton.tsx
+++ b/components/main/blocks/OpenDistributionButton/OpenDistributionButton.tsx
@@ -9,26 +9,32 @@ import { ImpactEvaluation } from "../../../../models";
 import { thousandize } from "../../../../util/formatting";
 import { getFormattedInterventionOutput } from "../OrganizationsList/OrganizationsList";
 
-export const OpenDistributionButton: React.FC<
-  Omit<Opendistributionbutton, "organization"> & {
-    organization: {
-      _type: "organization";
-      intervention?: {
-        abbreviation: string;
-        type: string;
-        effect: string;
-        scaling_factor?: number;
-      };
-      database_ids: {
-        cause_area_id: number;
-        organization_id: number;
-      };
-      impact_estimate: {
-        evaluation: ImpactEvaluation;
-      } | null;
+export type OpenDistributionButtonProps = Omit<Opendistributionbutton, "organization"> & {
+  organization: {
+    _type: "organization";
+    intervention?: {
+      abbreviation: string;
+      type: string;
+      effect: string;
+      scaling_factor?: number;
     };
-  }
-> = ({ text, inverted, organization, display_output_info, distribution_cause_areas }) => {
+    database_ids: {
+      cause_area_id: number;
+      organization_id: number;
+    };
+    impact_estimate: {
+      evaluation: ImpactEvaluation;
+    } | null;
+  };
+};
+
+export const OpenDistributionButton: React.FC<OpenDistributionButtonProps> = ({
+  text,
+  inverted,
+  organization,
+  display_output_info,
+  distribution_cause_areas,
+}) => {
   const [widgetContext, setWidgetContext] = useContext(WidgetContext);
   const plausible = usePlausible();
 

--- a/components/main/blocks/OpenDistributionButton/OpenDistributionButton.tsx
+++ b/components/main/blocks/OpenDistributionButton/OpenDistributionButton.tsx
@@ -5,25 +5,36 @@ import { WidgetContext } from "../../layout/layout";
 import { PrefilledDistribution } from "../../layout/WidgetPane/WidgetPane";
 import styles from "./OpenDistributionButton.module.scss";
 import { usePlausible } from "next-plausible";
+import { ImpactEvaluation } from "../../../../models";
+import { thousandize } from "../../../../util/formatting";
+import { getFormattedInterventionOutput } from "../OrganizationsList/OrganizationsList";
 
-export const OpenDistributionButton: React.FC<Opendistributionbutton> = ({
-  text,
-  inverted,
-  organization,
-  display_output_info,
-  distribution_cause_areas,
-}) => {
+export const OpenDistributionButton: React.FC<
+  Omit<Opendistributionbutton, "organization"> & {
+    organization: {
+      _type: "organization";
+      intervention?: {
+        abbreviation: string;
+        type: string;
+        effect: string;
+        scaling_factor?: number;
+      };
+      database_ids: {
+        cause_area_id: number;
+        organization_id: number;
+      };
+      impact_estimate: {
+        evaluation: ImpactEvaluation;
+      } | null;
+    };
+  }
+> = ({ text, inverted, organization, display_output_info, distribution_cause_areas }) => {
   const [widgetContext, setWidgetContext] = useContext(WidgetContext);
   const plausible = usePlausible();
 
   if (!distribution_cause_areas) {
     return null;
   }
-
-  const resolvedOrganization: Organization | null =
-    organization && organization._type !== "reference"
-      ? (organization as unknown as Organization)
-      : null;
 
   const prefilled = cleanDistribution(distribution_cause_areas);
 
@@ -34,10 +45,10 @@ export const OpenDistributionButton: React.FC<Opendistributionbutton> = ({
 
   return (
     <div className={containerStyles.join(" ")}>
-      {display_output_info && resolvedOrganization && (
+      {display_output_info && organization.intervention && organization.impact_estimate && (
         <div className={styles.outputInfo}>
-          <h2>{resolvedOrganization.invervention_cost}</h2>
-          <span>{resolvedOrganization.intervention_effect}</span>
+          <h2>{getFormattedInterventionOutput(organization)}</h2>
+          <span>{organization.intervention.effect}</span>
         </div>
       )}
       <div className={styles.buttonContainer}>

--- a/components/shared/components/Widget/components/hooks.ts
+++ b/components/shared/components/Widget/components/hooks.ts
@@ -63,8 +63,6 @@ export const usePrefilledDistribution = ({
       return;
     }
 
-    console.log("Applying prefill");
-
     causeAreas.forEach((causeArea) => {
       const prefilledCauseArea = prefilled.find(
         (prefilledArea) => prefilledArea.causeAreaId === causeArea.id,
@@ -137,14 +135,12 @@ export const useQueryParamsPrefill = ({
         prefilledSum: null,
       });
       hasAppliedQueryParams.current = true;
-      console.log("Applying query params");
     }
 
     if (recurring) {
       dispatch(setRecurring(RecurringDonation.RECURRING));
       setWidgetContext({ ...widgetContext, open: true });
       hasAppliedQueryParams.current = true;
-      console.log("Applying query params");
     }
   }, [inline, router.query, causeAreas, dispatch, setWidgetContext, widgetContext]);
 

--- a/pages/GenericPage.tsx
+++ b/pages/GenericPage.tsx
@@ -9,9 +9,9 @@ import { getClient } from "../lib/sanity.client";
 import { withStaticProps } from "../util/withStaticProps";
 import { GeneralPageProps, getAppStaticProps } from "./_app.page";
 import { token } from "../token";
-import { useLiveQuery } from "next-sanity/preview";
 import { stegaClean } from "@sanity/client/stega";
 import { ConsentState } from "../middleware.page";
+import { augmentStaticImpactEstimates } from "../util/staticImpactEstimateHelper";
 
 export const getGenericPagePaths = async () => {
   const data = await getClient().fetch<{ pages: Array<{ slug: { current: string } }> }>(
@@ -44,6 +44,21 @@ export const GenericPage = withStaticProps(
     if (result.settings[0].general_banner && result.settings[0].general_banner.link.slug == slug) {
       result.settings[0].general_banner = null;
     }
+
+    // Augment organizations with impact estimates
+    if (result.page && result.page.content) {
+      const augmentedContent = await augmentStaticImpactEstimates(result.page.content, "NOK", "no");
+
+      result = {
+        ...result,
+        page: {
+          ...result.page,
+          content: augmentedContent,
+        },
+      };
+    }
+
+    console.log(JSON.stringify(result.page.content, null, 2));
 
     return {
       appStaticProps,

--- a/pages/GenericPage.tsx
+++ b/pages/GenericPage.tsx
@@ -58,8 +58,6 @@ export const GenericPage = withStaticProps(
       };
     }
 
-    console.log(JSON.stringify(result.page.content, null, 2));
-
     return {
       appStaticProps,
       draftMode,

--- a/studio/components/organizationInput.tsx
+++ b/studio/components/organizationInput.tsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState } from "react";
+import { Stack, Card, Text, Select, Label, Flex, Box } from "@sanity/ui";
+import { PatchEvent, set, unset } from "sanity";
+
+// Types for our data structures
+type CauseArea = {
+  id: number;
+  name: string;
+  isActive: boolean;
+  organizations: Organization[];
+};
+
+type Organization = {
+  id: number;
+  name: string;
+  widgetDisplayName: string | null;
+  isActive: boolean;
+  causeAreaId: number;
+};
+
+// The value we'll store in Sanity
+type OrganizationReference = {
+  cause_area_id: number;
+  organization_id: number;
+};
+
+interface OrganizationSelectorProps {
+  value?: OrganizationReference;
+  onChange: (event: PatchEvent) => void;
+}
+
+const api = process.env.SANITY_STUDIO_EFFEKT_API_URL;
+
+// OrganizationSelector Component for Sanity
+export const OrganizationSelector = React.forwardRef<HTMLDivElement, OrganizationSelectorProps>(
+  (props, ref) => {
+    const [causeAreas, setCauseAreas] = useState<CauseArea[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const [selectedCauseAreaId, setSelectedCauseAreaId] = useState<number | null>(
+      props.value?.cause_area_id || null,
+    );
+    const [selectedOrganizationId, setSelectedOrganizationId] = useState<number | null>(
+      props.value?.organization_id || null,
+    );
+
+    // Fetch all cause areas and organizations
+    useEffect(() => {
+      setLoading(true);
+      fetch(`${api}/causeareas/all`)
+        .then((response) => response.json())
+        .then((data) => {
+          if (data && data.content) {
+            // Filter to only active cause areas
+            const activeCauseAreas = data.content.filter((area: CauseArea) => area.isActive);
+            setCauseAreas(activeCauseAreas);
+            setLoading(false);
+          }
+        })
+        .catch((err) => {
+          console.error("Error fetching data:", err);
+          setError("Failed to load cause areas");
+          setLoading(false);
+        });
+    }, []);
+
+    // Initialize selected values from props if they exist
+    useEffect(() => {
+      if (props.value) {
+        setSelectedCauseAreaId(props.value.cause_area_id);
+        setSelectedOrganizationId(props.value.organization_id);
+      }
+    }, [props.value]);
+
+    // Handle cause area selection
+    const handleCauseAreaChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const causeAreaId = parseInt(event.currentTarget.value, 10);
+
+      if (isNaN(causeAreaId)) {
+        // Empty selection
+        setSelectedCauseAreaId(null);
+        setSelectedOrganizationId(null);
+        props.onChange(PatchEvent.from(unset()));
+        return;
+      }
+
+      setSelectedCauseAreaId(causeAreaId);
+      setSelectedOrganizationId(null);
+
+      // Update Sanity value (only cause area for now)
+      if (causeAreaId) {
+        props.onChange(
+          PatchEvent.from(
+            set({
+              cause_area_id: causeAreaId,
+              organization_id: null,
+            }),
+          ),
+        );
+      }
+    };
+
+    // Handle organization selection
+    const handleOrganizationChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+      const organizationId = parseInt(event.currentTarget.value, 10);
+
+      if (isNaN(organizationId)) {
+        // Empty selection
+        setSelectedOrganizationId(null);
+
+        // Update Sanity with just the cause area
+        if (selectedCauseAreaId) {
+          props.onChange(
+            PatchEvent.from(
+              set({
+                cause_area_id: selectedCauseAreaId,
+                organization_id: null,
+              }),
+            ),
+          );
+        }
+        return;
+      }
+
+      setSelectedOrganizationId(organizationId);
+
+      // Update Sanity with both values
+      if (selectedCauseAreaId) {
+        props.onChange(
+          PatchEvent.from(
+            set({
+              cause_area_id: selectedCauseAreaId,
+              organization_id: organizationId,
+            }),
+          ),
+        );
+      }
+    };
+
+    // Get available organizations for the selected cause area
+    const getAvailableOrganizations = () => {
+      if (!selectedCauseAreaId) return [];
+
+      const causeArea = causeAreas.find((area) => area.id === selectedCauseAreaId);
+      if (!causeArea) return [];
+
+      return causeArea.organizations.filter((org) => org.isActive);
+    };
+
+    // Get selected cause area name (for display)
+    const getSelectedCauseAreaName = () => {
+      if (!selectedCauseAreaId) return "";
+      const causeArea = causeAreas.find((area) => area.id === selectedCauseAreaId);
+      return causeArea ? causeArea.name : "";
+    };
+
+    // Get selected organization name (for display)
+    const getSelectedOrganizationName = () => {
+      if (!selectedCauseAreaId || !selectedOrganizationId) return "";
+
+      const causeArea = causeAreas.find((area) => area.id === selectedCauseAreaId);
+      if (!causeArea) return "";
+
+      const org = causeArea.organizations.find((org) => org.id === selectedOrganizationId);
+      return org ? org.widgetDisplayName || org.name : "";
+    };
+
+    if (loading) return <Text>Loading data...</Text>;
+    if (error) return <Text>{error}</Text>;
+
+    return (
+      <div ref={ref}>
+        <Stack space={4}>
+          <Card
+            padding={3}
+            radius={2}
+            tone={!selectedCauseAreaId || !selectedOrganizationId ? "critical" : undefined}
+            border
+          >
+            <Stack space={3}>
+              {/* Cause Area Selection */}
+              <Flex align="center">
+                <Box flex={1}>
+                  <Label htmlFor="cause-area-select">Cause Area</Label>
+                </Box>
+                <Box flex={1}>
+                  <Select
+                    id="cause-area-select"
+                    onChange={handleCauseAreaChange}
+                    value={selectedCauseAreaId?.toString() || ""}
+                  >
+                    <option value="">Select a cause area</option>
+                    {causeAreas.map((area) => (
+                      <option key={area.id} value={area.id.toString()}>
+                        {area.name}
+                      </option>
+                    ))}
+                  </Select>
+                </Box>
+              </Flex>
+
+              {/* Organization Selection (only shown if cause area is selected) */}
+              {selectedCauseAreaId && (
+                <Flex align="center">
+                  <Box flex={1}>
+                    <Label htmlFor="organization-select">Organization</Label>
+                  </Box>
+                  <Box flex={1}>
+                    <Select
+                      id="organization-select"
+                      onChange={handleOrganizationChange}
+                      value={selectedOrganizationId?.toString() || ""}
+                    >
+                      <option value="">Select an organization</option>
+                      {getAvailableOrganizations().map((org) => (
+                        <option key={org.id} value={org.id.toString()}>
+                          {org.widgetDisplayName || org.name}
+                        </option>
+                      ))}
+                    </Select>
+                  </Box>
+                </Flex>
+              )}
+            </Stack>
+          </Card>
+        </Stack>
+      </div>
+    );
+  },
+);

--- a/studio/deskStructure.ts
+++ b/studio/deskStructure.ts
@@ -176,6 +176,10 @@ export const deskStructure = (S) =>
             ]),
         ),
       S.listItem()
+        .title("Organizations")
+        .icon(Briefcase)
+        .child(S.documentTypeList("organization").title("Organizations")),
+      S.listItem()
         .title("Categories")
         .icon(Filter)
         .child(S.documentTypeList("category").title("Page and article categories")),

--- a/studio/schemas/types/intervention.ts
+++ b/studio/schemas/types/intervention.ts
@@ -7,16 +7,14 @@ export default {
       name: "title",
       type: "string",
       title: "Title",
+      description:
+        "The title for the buttons that will be shown in the widget, defaults to the organizations intervention type",
     },
     {
-      name: "organization_name",
-      type: "string",
-      title: "Organization name",
-    },
-    {
-      name: "abbreviation",
-      type: "string",
-      title: "Abbreviation",
+      name: "organization",
+      type: "reference",
+      to: [{ type: "organization" }],
+      title: "Organization",
     },
     {
       name: "template_string",
@@ -25,14 +23,11 @@ export default {
       title: "Template string",
     },
     {
-      name: "organization_id",
-      type: "number",
-      title: "Organization ID",
-    },
-    {
-      name: "cause_area_id",
-      type: "number",
-      title: "Cause area ID",
+      name: "template_donate_button",
+      type: "string",
+      title: "Template donate button",
+      description:
+        "The template string for the donate button. Use {outputs} to insert the number of outputs",
     },
   ],
 } as const;

--- a/studio/schemas/types/organization.ts
+++ b/studio/schemas/types/organization.ts
@@ -1,3 +1,5 @@
+import { OrganizationSelector } from "../../components/organizationInput";
+
 export default {
   name: "organization",
   type: "document",
@@ -20,11 +22,6 @@ export default {
       type: "string",
     },
     {
-      name: "abbriviation",
-      type: "string",
-      title: "Abbriviation",
-    },
-    {
       name: "oneliner",
       type: "string",
       title: "Oneliner",
@@ -34,24 +31,6 @@ export default {
       title: "Content",
       type: "array",
       of: [{ type: "block" }],
-    },
-    {
-      name: "intervention_type",
-      title: "Intervention type",
-      type: "string",
-      group: "intervention",
-    },
-    {
-      name: "invervention_cost",
-      title: "Intervention cost",
-      type: "string",
-      group: "intervention",
-    },
-    {
-      name: "intervention_effect",
-      title: "Intervention effect",
-      type: "string",
-      group: "intervention",
     },
     {
       name: "logo",
@@ -70,6 +49,36 @@ export default {
       of: [{ type: "link" }],
     },
     {
+      name: "database_ids",
+      title: "Database ids",
+      type: "object",
+      description:
+        "Set the cause area and organization id for the donation coresponding to the ones used in the database. Used for the widget button",
+      fields: [
+        {
+          name: "cause_area_id",
+          title: "Impact id",
+          type: "number",
+        },
+        {
+          name: "organization_id",
+          title: "Organization id",
+          type: "number",
+        },
+      ],
+      validation: (Rule: any) => {
+        return Rule.required().custom((fields: any) => {
+          if (fields.cause_area_id && fields.organization_id) {
+            return true;
+          }
+          return "Both cause_area_id and organization_id must be set";
+        });
+      },
+      components: {
+        input: OrganizationSelector,
+      },
+    },
+    {
       name: "widget_button",
       title: "Widget button",
       type: "object",
@@ -80,14 +89,54 @@ export default {
           type: "string",
         },
         {
-          name: "cause_area_id",
-          title: "Cause area id",
-          type: "number",
+          name: "display",
+          title: "Display",
+          type: "boolean",
+          description:
+            "Whether to display the widget button, which opens the widget with the organization prefilled to 100% of the donation",
+        },
+      ],
+      hidden: ({ parent }: any) =>
+        !parent.database_ids ||
+        !parent.database_ids.cause_area_id ||
+        !parent.database_ids.organization_id,
+    },
+    {
+      name: "intervention",
+      title: "Intervention",
+      type: "object",
+      fields: [
+        {
+          name: "abbreviation",
+          type: "string",
+          title: "Abbreviation",
+          description: "Used to fetch impact estimates from the impact API",
         },
         {
-          name: "organization_id",
-          title: "Organization id",
+          name: "type",
+          type: "string",
+          title: "Intervention type",
+          description:
+            "The type of intervention, output to just get the cost per output in local currency, percentage to get the percantage that goes to the intervention (e.g. cash transfers), and scaled_output to get the cost per output scaled to some constant (e.g. 2 vitamin-A supplements to cover a child for a year)",
+          options: {
+            list: [
+              { title: "Output", value: "output" },
+              { title: "Percentage", value: "percentage" },
+              { title: "Scaled output", value: "scaled_output" },
+            ],
+          },
+        },
+        {
+          name: "scaling_factor",
           type: "number",
+          title: "Intervention scaling factor",
+          description: "The scaling factor to use for scaled_output interventions",
+          hidden: ({ parent }: any) => parent && parent.type !== "scaled_output",
+        },
+        {
+          name: "effect",
+          type: "string",
+          title: "Intervention effect",
         },
       ],
     },

--- a/util/staticImpactEstimateHelper.ts
+++ b/util/staticImpactEstimateHelper.ts
@@ -1,0 +1,71 @@
+import { stegaClean } from "next-sanity";
+
+/**
+ * This function looks at page content and looks for docs with type organization
+ * We find the impact estimates with the impact estimate API, and augment the content with the impact estimates
+ */
+export const augmentStaticImpactEstimates = async (
+  content: ({ _type?: string } & any)[] | ({ _type?: string } & any),
+  currency: string,
+  locale: string,
+) => {
+  // Recursively loop over every single property in the content
+  if (Array.isArray(content)) {
+    for (const item of content) {
+      if (item && typeof item === "object") {
+        await augmentStaticImpactEstimates(item, currency, locale);
+      }
+    }
+  } else if (content && typeof content === "object") {
+    const keys = Object.keys(content);
+    for (const key of keys) {
+      if (content[key] && typeof content[key] === "object") {
+        await augmentStaticImpactEstimates(content[key], currency, locale);
+      } else if (key === "_type" && content[key] === "organization") {
+        // We found an organization, let's get the impact estimate
+        if (content["intervention"]) {
+          const organizationAbreviation = content["intervention"]["abbreviation"];
+          const impactEstimate = await getImpactEstimate(organizationAbreviation, currency, locale);
+          content["impact_estimate"] = impactEstimate;
+        }
+      }
+    }
+  }
+
+  return content;
+};
+
+const getImpactEstimate = async (
+  organizationAbreviation: string,
+  currency: string,
+  language: string,
+) => {
+  const currentDate = new Date();
+
+  const url = `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${stegaClean(
+    organizationAbreviation,
+  )}&currency=${stegaClean(currency)}&language=${stegaClean(
+    language,
+  )}&conversion_year=${currentDate.getFullYear()}&conversion_month=${currentDate.getMonth() + 1}`;
+
+  try {
+    const response = await fetch(url);
+    const data = await response.json();
+
+    // If there are evaluations, sort them by start_year to get the most recent
+    if (data.evaluations && data.evaluations.length > 0) {
+      const orderedEvaluations = data.evaluations.sort(
+        (a: any, b: any) => b.start_year - a.start_year,
+      );
+      return {
+        evaluation: orderedEvaluations[0], // Return only the most recent evaluation
+      };
+    }
+
+    // Return empty evaluations array if no evaluations found
+    return null;
+  } catch (error) {
+    console.error("Error fetching impact estimate:", error);
+    return null;
+  }
+};


### PR DESCRIPTION
This links the cost per output from the impact API and removes all hard-coding of cost for outputs in Sanity. This will also make sure that the costs reflect currency changes. Since it's done statically, data may become slightly out of date, but in general we build new versions of the page very often, so it should not be a big issue.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
