### PR TITLE
Only show 'Min side' button when currency is not DKK

### DIFF
--- a/components/shared/components/Navbar/Navbar.tsx
+++ b/components/shared/components/Navbar/Navbar.tsx
@@ -40,6 +40,7 @@ export type NavBarQueryResult = {
     main_navigation: MainNavbarItem[];
     donate_label: string;
     accent_color: string;
+    main_currency: string;
   };
   dashboard: {
     main_navigation: MainNavbarItem[];
@@ -77,6 +78,7 @@ const query = groq`
     logo,
     donate_label,
     accent_color,
+    main_currency,
     main_navigation[] {
       _type == 'navgroup' => {
         _type,
@@ -305,14 +307,16 @@ export const Navbar = withStaticProps(
                 {labels.logout}
               </EffektButton>
             ) : (
-              <CustomLink href={dashboardPath.join("/")} tabIndex={-1}>
-                <EffektButton
-                  variant={EffektButtonVariant.SECONDARY}
-                  onClick={() => setExpanded(false)}
-                >
-                  {labels.dashboard}
-                </EffektButton>
-              </CustomLink>
+              settingsData.main_currency !== "DKK" && (
+                <CustomLink href={dashboardPath.join("/")} tabIndex={-1}>
+                  <EffektButton
+                    variant={EffektButtonVariant.SECONDARY}
+                    onClick={() => setExpanded(false)}
+                  >
+                    {labels.dashboard}
+                  </EffektButton>
+                </CustomLink>
+              )
             )}
             <EffektButton
               cy="send-donation-button"


### PR DESCRIPTION
## Description
This PR modifies the Navbar component to only show the 'Min side' button when the site's currency is set to DKK.

## Changes
- Added `main_currency` to the `NavBarQueryResult` type definition
- Added `main_currency` to the Sanity query to fetch this field from site settings
- Added a conditional check to only render the dashboard button when `settingsData.main_currency !== "DKK"`

The 'Min side' button will now only display in the Danish version of the site, and will be hidden for other currencies (NOK, SEK, EUR, etc.).
