### PR TITLE
Reset method when recurring status changes in widget

### DIFF
--- a/components/shared/components/Widget/store/donation/reducer.ts
+++ b/components/shared/components/Widget/store/donation/reducer.ts
@@ -150,7 +150,11 @@ export const donationReducer: Reducer<Donation, DonationActionTypes> = (
       state = { ...state, dueDay: action.payload.day };
       break;
     case SET_RECURRING:
-      state = { ...state, recurring: action.payload.recurring };
+      state = {
+        ...state,
+        recurring: action.payload.recurring,
+        method: undefined,
+      };
       break;
     case SET_KID:
       state = { ...state, kid: action.payload.kid };


### PR DESCRIPTION
Resets payment method when recurring status changes to avoid sending invalid data to the backend if the previously selected payment method does not support recurring and the user switches in the widget.

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
