### PR TITLE
Increased Title container top spacing to avoid menu overlap on mobile

### DIFF
--- a/components/shared/layout/Layout/Layout.module.scss
+++ b/components/shared/layout/Layout/Layout.module.scss
@@ -31,6 +31,7 @@
 @media only screen and (max-width: 1180px) {
   .container {
     padding-top: 72px;
+    margin-top: 20px;
   }
 }
 


### PR DESCRIPTION
_Issue description here_
Fixed issue with Title container top spacing to avoid menu overlap on mobile on the following page

- giveffektivt.dk/vores-metode
- giveffektivt.dk/x-faktor
- giveffektivt.dk/testamente
- giveffektivt.dk/procentloftet
- https://giveffektivt.dk/almindelige-sporgsmal
- [https://giveffektivt.dk/](https://giveffektivt.dk/almindelige-sporgsmal)blog

- closes #linked-issue-nr

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
