### PR TITLE
Ensure widget inputs inherit site font

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -42,6 +42,13 @@ body {
   overflow-x: hidden;
 }
 
+input,
+button,
+select,
+textarea {
+  font: inherit;
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
## Summary
- fix Smart fordeling inputs rendering with the system font instead of ESKlarheitGrotesk
- apply a global font reset so all form controls inherit the site typography

## Testing
- not run (CSS-only change)
