### PR TITLE
Fixed mobile header spacing on generic and article pages

### DIFF
--- a/components/main/layout/ArticleHeader/ArticleHeader.module.scss
+++ b/components/main/layout/ArticleHeader/ArticleHeader.module.scss
@@ -55,7 +55,7 @@
 @media only screen and (max-width: 1180px) {
   .articleheader {
     padding-top: 0;
-    min-height: 70vh;
+    min-height: 70px;
     grid-auto-rows: max-content;
   }
 
@@ -67,7 +67,7 @@
   }
 
   .articleheader h1 {
-    margin-top: 180px;
+    margin-top: 0;
     font-size: 2rem;
     text-align: left;
     word-break: break-word;

--- a/components/main/layout/ArticleHeader/ArticleHeader.module.scss
+++ b/components/main/layout/ArticleHeader/ArticleHeader.module.scss
@@ -67,7 +67,7 @@
   }
 
   .articleheader h1 {
-    margin-top: 0;
+    margin-top: 2rem;
     font-size: 2rem;
     text-align: left;
     word-break: break-word;

--- a/components/main/layout/PageHeader/PageHeader.module.scss
+++ b/components/main/layout/PageHeader/PageHeader.module.scss
@@ -99,11 +99,17 @@
   .pageheader.hero,
   .pageheader.pageheadermeta.hero {
     min-height: calc(120px + 30vh);
+
     align-content: flex-end;
-    padding-top: 3rem;
+    padding-top: 0;
     padding-bottom: 3rem;
   }
-
+  .pageheader.centered,
+  .pageheader.pageheadermeta.centered {
+    grid-template-columns: 1fr;
+    text-align: center;
+    padding-top: 0;
+  }
   .pageheader.hero div h1 {
     margin-bottom: 16px;
     font-size: 48px;
@@ -128,7 +134,7 @@
 
   .pageheader,
   .pageheader.pageheadermeta {
-    min-height: calc(120px + 30vh);
+    min-height: auto;
     padding-left: 5vw;
     padding-right: 5vw;
     display: grid;


### PR DESCRIPTION
_Issue description here_
**Generic and article pages showed a large white gap between the fixed nav and the page title in mobile view.**

**Fixed mobile header spacing on generic and article pages**
- Collapsed generic page headers on small screens by removing the forced 30vh minimum height and top alignment that created a large gap under the nav
- Updated article headers to drop hardcoded min-heights/padding and reset hero margins so the title sits directly under the navigation on phones

- closes #linked-issue-nr

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thorough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
