### PR TITLE
Add support for DK impact

### DIFF
--- a/components/profile/donations/DonationImpact/DonationImpact.tsx
+++ b/components/profile/donations/DonationImpact/DonationImpact.tsx
@@ -1,18 +1,14 @@
 import React, { useCallback, useState } from "react";
-import useSWR from "swr";
-import { Distribution, DistributionCauseArea, Donation, GiveWellGrant } from "../../../../models";
-import { thousandize } from "../../../../util/formatting";
+import { Distribution, DistributionCauseArea, Donation } from "../../../../models";
 import style from "./DonationImpact.module.scss";
+import ghStyle from "./GlobalHealth/DonationImpactGlobalHealth.module.scss";
 import {
   DonationImpactGlobalHealthItem,
   ImpactItemConfiguration,
 } from "./GlobalHealth/DonationImpactItemGlobalHealth";
-import { ErrorMessage } from "../../shared/ErrorMessage/ErrorMessage";
 import DonationImpactGlobalHealth from "./GlobalHealth/DonationImpactGlobalHealth";
 import DonationImpactAnimalWelfare from "./AnimalWelfare/DonationImpactAnimalWelfare";
 import { mapNameToOrgAbbriv } from "../../../../util/mappings";
-
-const fetcher = (url: string) => fetch(url).then((res) => res.json());
 
 export type DonationImpactItemsConfiguration = {
   currency: string;
@@ -28,6 +24,43 @@ const DonationImpact: React.FC<{
   timestamp: Date;
   configuration: DonationImpactItemsConfiguration;
 }> = ({ donation, distribution, timestamp, configuration }) => {
+  const [requiredPrecision, setRequiredPrecision] = useState(0);
+  const updatePrecision = useCallback(
+    (precision: number) => {
+      if (precision > requiredPrecision) setRequiredPrecision(precision);
+    },
+    [requiredPrecision],
+  );
+
+  if (donation.impact?.length) {
+    return (
+      <div className={ghStyle.container}>
+        <table className={ghStyle.wrapper} cellSpacing={0} data-cy="donation-impact-list">
+          <tbody>
+            {donation.impact.map((entry, i) => (
+              <DonationImpactGlobalHealthItem
+                key={`${donation.id}-impact-${i}`}
+                orgAbriv=""
+                orgName={entry.recipient}
+                sumToOrg={entry.amount}
+                donationTimestamp={timestamp}
+                precision={requiredPrecision}
+                signalRequiredPrecision={updatePrecision}
+                configuration={configuration.impact_item_configuration}
+                preComputedImpact={{
+                  output: entry.count,
+                  shortDescription: entry.unit,
+                  longDescription: entry.description,
+                  linkSubject: entry.unit,
+                }}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+
   return (
     <>
       {distribution.causeAreas.map((causeArea: DistributionCauseArea) => (

--- a/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
+++ b/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
@@ -54,6 +54,13 @@ const renderGiveWellAllGrantsFundContent = (configuration: ImpactItemConfigurati
   );
 };
 
+export type PreComputedImpact = {
+  output: number;
+  shortDescription: string;
+  longDescription: string;
+  linkSubject: string;
+};
+
 export const DonationImpactGlobalHealthItem: React.FC<{
   orgAbriv: string;
   orgName: string;
@@ -62,6 +69,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
   precision: number;
   signalRequiredPrecision: (precision: number) => void;
   configuration: ImpactItemConfiguration;
+  preComputedImpact?: PreComputedImpact;
 }> = ({
   orgAbriv,
   orgName,
@@ -70,15 +78,18 @@ export const DonationImpactGlobalHealthItem: React.FC<{
   precision,
   signalRequiredPrecision,
   configuration,
+  preComputedImpact,
 }) => {
   const { data, error, isValidating } = useSWR<{ evaluations: ImpactEvaluation[] }>(
-    `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${orgAbriv}&currency=${
-      configuration.currency
-    }&language=${
-      configuration.locale
-    }&donation_year=${donationTimestamp.getFullYear()}&donation_month=${
-      donationTimestamp.getMonth() + 1
-    }`,
+    preComputedImpact
+      ? null
+      : `https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=${orgAbriv}&currency=${
+          configuration.currency
+        }&language=${
+          configuration.locale
+        }&donation_year=${donationTimestamp.getFullYear()}&donation_month=${
+          donationTimestamp.getMonth() + 1
+        }`,
     fetcher,
     {
       revalidateIfStale: false,
@@ -95,32 +106,53 @@ export const DonationImpactGlobalHealthItem: React.FC<{
     }
   }, [precision, requiredPrecision]);
 
-  if (!data || isValidating) {
-    return (
-      <tr key={`loading`}>
-        <td>Loading...</td>
-      </tr>
-    );
+  if (!preComputedImpact) {
+    if (!data || isValidating) {
+      return (
+        <tr key={`loading`}>
+          <td>Loading...</td>
+        </tr>
+      );
+    }
+    if (error) {
+      return (
+        <tr key={`error`}>
+          <td>{error}</td>
+        </tr>
+      );
+    }
   }
-  if (error) {
-    return (
-      <tr key={`error`}>
-        <td>{error}</td>
-      </tr>
-    );
-  }
+
   /**
    * Sort evaluations by start time
    * Then return the first evaluation that has a start year and month less than or equal to the donation
    * This will be the most recent relevant evaluation to calculate the impact
    */
   const relevantEvaluation = data?.evaluations[0];
+  const resolvedImpact: {
+    output: number;
+    shortDescription: string;
+    longDescription: string;
+    charityName: string;
+    linkSubject: string;
+  } | null = preComputedImpact
+    ? { ...preComputedImpact, charityName: orgName }
+    : relevantEvaluation
+    ? {
+        output: sumToOrg / relevantEvaluation.converted_cost_per_output,
+        shortDescription: relevantEvaluation.intervention.short_description,
+        longDescription: relevantEvaluation.intervention.long_description,
+        charityName: relevantEvaluation.charity.charity_name,
+        linkSubject: relevantEvaluation.charity.charity_name,
+      }
+    : null;
+
   const isGiveWellAllGrantsFund = orgAbriv === "AGF";
   const missingEvaluationHeader = isGiveWellAllGrantsFund
     ? configuration.givewell_all_grants_fund_header ?? configuration.missing_evaluation_header
     : configuration.missing_evaluation_header;
 
-  if (!relevantEvaluation) {
+  if (!resolvedImpact) {
     return (
       <>
         <tr className={style.overview} data-cy="donation-impact-list-item-overview">
@@ -169,7 +201,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
     );
   }
 
-  const output = sumToOrg / relevantEvaluation.converted_cost_per_output;
+  const output = resolvedImpact.output;
 
   let tmpRequiredPrecision = 0;
   while (parseFloat(output.toFixed(tmpRequiredPrecision)) === 0 && tmpRequiredPrecision < 3) {
@@ -196,7 +228,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
         <td>
           <div className={style.impactContext}>
             <span className={style.impactDetailsDescription}>
-              {relevantEvaluation.intervention.short_description}
+              {resolvedImpact.shortDescription}
             </span>
             <span
               className={[style.impactDetailsExpandText, showDetails ? style.expanded : ""].join(
@@ -206,7 +238,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
             >
               {configuration.output_subheading_format_string
                 .replace("{{sum}}", thousandize(Math.round(sumToOrg)))
-                .replace("{{org}}", relevantEvaluation.charity.charity_name)}
+                .replace("{{org}}", resolvedImpact.charityName)}
             </span>
           </div>
         </td>
@@ -216,7 +248,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
           {/* Strange hack required to not have table reflow when showing the animated area */}
           <AnimateHeight duration={300} animateOpacity height={showDetails ? "auto" : 0}>
             <div>
-              <p>{relevantEvaluation.intervention.long_description}</p>
+              <p>{resolvedImpact.longDescription}</p>
               <div>
                 <Links
                   links={[
@@ -225,10 +257,10 @@ export const DonationImpactGlobalHealthItem: React.FC<{
                       _key: "charity_description",
                       title: configuration.about_org_link_title_format_string.replace(
                         "{{org}}",
-                        relevantEvaluation.charity.charity_name,
+                        resolvedImpact.linkSubject,
                       ),
                       url: configuration.about_org_link_url_format_string
-                        .replace("{{org}}", relevantEvaluation.charity.charity_name)
+                        .replace("{{org}}", resolvedImpact.linkSubject)
                         .replaceAll(" ", "_"),
                       newtab: true,
                     },

--- a/components/profile/donations/DonationsAggregateImpactTable/DistributionsRow.tsx
+++ b/components/profile/donations/DonationsAggregateImpactTable/DistributionsRow.tsx
@@ -3,7 +3,7 @@ import AnimateHeight from "react-animate-height";
 import { ChevronDown } from "react-feather";
 import { thousandize, thousandizeString } from "../../../../util/formatting";
 import style from "./DonationsAggregateImpactTable.module.scss";
-import { AggregatedImpact, GIVEWELL_ALL_GRANTS_FUND_KEY } from "./_util";
+import { AggregatedImpact, DK_OPERATIONS_KEY, GIVEWELL_ALL_GRANTS_FUND_KEY } from "./_util";
 
 const multiFetcher = (...urls: string[]) => {
   const f = (u: string) => fetch(u).then((r) => r.json());
@@ -29,7 +29,8 @@ export const DistributionsRow: React.FC<{
       .replace(/\./, ","),
   );
 
-  const isDriftRow = outputkey.toLowerCase().indexOf("drift") !== -1;
+  const isDriftRow =
+    outputkey.toLowerCase().indexOf("drift") !== -1 || outputkey === DK_OPERATIONS_KEY;
   const isAllGrantsFundRow = outputkey === GIVEWELL_ALL_GRANTS_FUND_KEY;
 
   if (isDriftRow || isAllGrantsFundRow) {

--- a/components/profile/donations/DonationsAggregateImpactTable/DonationsAggregateImpactTable.tsx
+++ b/components/profile/donations/DonationsAggregateImpactTable/DonationsAggregateImpactTable.tsx
@@ -10,6 +10,7 @@ import {
   AggregatedImpact,
   aggregateImpact,
   aggregateOrgSumByYearAndMonth,
+  DK_OPERATIONS_KEY,
   GIVEWELL_ALL_GRANTS_FUND_KEY,
 } from "./_util";
 import { mapNameToOrgAbbriv } from "../../../../util/mappings";
@@ -123,10 +124,15 @@ export const DonationsAggregateImpactTable: React.FC<{
   if (isDK) {
     donations.forEach((donation) => {
       donation.impact?.forEach((entry) => {
-        impact[entry.unit] ??= { outputs: 0, constituents: {} };
-        impact[entry.unit].outputs += entry.count;
-        impact[entry.unit].constituents[entry.recipient] ??= 0;
-        impact[entry.unit].constituents[entry.recipient] += entry.amount;
+        if (entry.recipient === "Giv Effektivt") {
+          impact[DK_OPERATIONS_KEY] ??= { outputs: 0, constituents: {} };
+          impact[DK_OPERATIONS_KEY].outputs += entry.amount;
+        } else {
+          impact[entry.unit] ??= { outputs: 0, constituents: {} };
+          impact[entry.unit].outputs += entry.count;
+          impact[entry.unit].constituents[entry.recipient] ??= 0;
+          impact[entry.unit].constituents[entry.recipient] += entry.amount;
+        }
       });
     });
     loading = false;
@@ -211,7 +217,8 @@ export const DonationsAggregateImpactTable: React.FC<{
                 .filter(
                   (key) =>
                     key.toLowerCase().indexOf("drift") === -1 &&
-                    key !== GIVEWELL_ALL_GRANTS_FUND_KEY,
+                    key !== GIVEWELL_ALL_GRANTS_FUND_KEY &&
+                    key !== DK_OPERATIONS_KEY,
                 )
                 .sort((a: string, b: string) => (b < a ? 1 : -1))
                 .map((key: string) => (
@@ -225,7 +232,8 @@ export const DonationsAggregateImpactTable: React.FC<{
                 .filter(
                   (key) =>
                     key.toLowerCase().indexOf("drift") !== -1 ||
-                    key === GIVEWELL_ALL_GRANTS_FUND_KEY,
+                    key === GIVEWELL_ALL_GRANTS_FUND_KEY ||
+                    key === DK_OPERATIONS_KEY,
                 )
                 .sort((a: string, b: string) => {
                   if (a === GIVEWELL_ALL_GRANTS_FUND_KEY && b !== GIVEWELL_ALL_GRANTS_FUND_KEY)

--- a/components/profile/donations/DonationsAggregateImpactTable/DonationsAggregateImpactTable.tsx
+++ b/components/profile/donations/DonationsAggregateImpactTable/DonationsAggregateImpactTable.tsx
@@ -7,6 +7,7 @@ import { Distribution, Donation, GiveWellGrant, ImpactEvaluation } from "../../.
 import { DistributionsRow } from "./DistributionsRow";
 import { LoadingButtonSpinner } from "../../../shared/components/Spinner/LoadingButtonSpinner";
 import {
+  AggregatedImpact,
   aggregateImpact,
   aggregateOrgSumByYearAndMonth,
   GIVEWELL_ALL_GRANTS_FUND_KEY,
@@ -34,6 +35,7 @@ export const DonationsAggregateImpactTable: React.FC<{
   configuration: AggregatedImpactTableConfiguration;
   defaultExpanded?: boolean;
 }> = ({ donations, distributionMap, configuration, defaultExpanded = true }) => {
+  const isDK = configuration.locale === "dk";
   const [expanded, setExpanded] = useState(
     defaultExpanded || (typeof window !== "undefined" && window.innerWidth > 1180),
   );
@@ -48,7 +50,9 @@ export const DonationsAggregateImpactTable: React.FC<{
     error: impacterror,
     isValidating: impactvalidating,
   } = useSWR<{ max_impact_fund_grants: GiveWellGrant[] }>(
-    `https://impact.gieffektivt.no/api/max_impact_fund_grants?currency=${configuration.currency}&language=${configuration.locale}`,
+    isDK
+      ? null
+      : `https://impact.gieffektivt.no/api/max_impact_fund_grants?currency=${configuration.currency}&language=${configuration.locale}`,
     fetcher,
     {
       revalidateIfStale: false,
@@ -84,11 +88,15 @@ export const DonationsAggregateImpactTable: React.FC<{
     data: evaluationdata,
     error: evaluationerror,
     isValidating: evaluationvalidating,
-  } = useSWR<{ evaluations: ImpactEvaluation[] }[]>(urls, (urls) => multiFetcher(urls), {
-    revalidateIfStale: false,
-    revalidateOnFocus: false,
-    revalidateOnReconnect: false,
-  });
+  } = useSWR<{ evaluations: ImpactEvaluation[] }[]>(
+    isDK ? null : urls,
+    (urls) => multiFetcher(urls),
+    {
+      revalidateIfStale: false,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    },
+  );
 
   useLayoutEffect(() => {
     if (
@@ -105,14 +113,24 @@ export const DonationsAggregateImpactTable: React.FC<{
     }
   }, [impactdata, evaluationdata]);
 
-  let impact = {};
+  let impact: AggregatedImpact = {};
   let loading = true;
   let mappedEvaluations = [];
   let templateStrings = {
     org_direct_template_string: configuration.org_direct_template_string,
     org_grant_template_string: configuration.org_grant_template_string,
   };
-  if (impactdata && !impactvalidating && evaluationdata && !evaluationvalidating) {
+  if (isDK) {
+    donations.forEach((donation) => {
+      donation.impact?.forEach((entry) => {
+        impact[entry.unit] ??= { outputs: 0, constituents: {} };
+        impact[entry.unit].outputs += entry.count;
+        impact[entry.unit].constituents[entry.recipient] ??= 0;
+        impact[entry.unit].constituents[entry.recipient] += entry.amount;
+      });
+    });
+    loading = false;
+  } else if (impactdata && !impactvalidating && evaluationdata && !evaluationvalidating) {
     mappedEvaluations = evaluationdata.map((d) => d.evaluations).flat();
     impact = aggregateImpact(aggregated, mappedEvaluations, templateStrings);
     loading = false;

--- a/components/profile/donations/DonationsAggregateImpactTable/_util.ts
+++ b/components/profile/donations/DonationsAggregateImpactTable/_util.ts
@@ -35,6 +35,7 @@ export type AggregatedImpact = {
 };
 
 export const GIVEWELL_ALL_GRANTS_FUND_KEY = "GiveWell All Grants Fund";
+export const DK_OPERATIONS_KEY = "Giv Effektivts arbejde og vækst";
 
 /**
  * Takes a list of donations and distributions and GiveWell grants

--- a/components/profile/shared/lists/donationList/DonationDetails.tsx
+++ b/components/profile/shared/lists/donationList/DonationDetails.tsx
@@ -27,7 +27,7 @@ export const DonationDetails: React.FC<{
 }> = ({ sum, donation, distribution, timestamp, configuration }) => {
   const [showImpactEstimateExplanation, setShowImpactEstimateExplanation] = useState(false);
 
-  if (!distribution)
+  if (!distribution && !donation.impact?.length)
     return <span>Ingen distribusjon funnet for donasjon med KID {donation.KID}</span>;
 
   return (

--- a/models.ts
+++ b/models.ts
@@ -6,6 +6,14 @@ export enum META_OWNER {
   EFFEKTANDEAN = 3,
 }
 
+export type DonationImpactEntry = {
+  recipient: string;
+  unit: string;
+  amount: number;
+  count: number;
+  description: string;
+};
+
 export type Donation = {
   KID: string;
   donor: string;
@@ -17,6 +25,7 @@ export type Donation = {
   timestamp: string;
   transactionCost: string;
   metaOwnerId: META_OWNER;
+  impact?: DonationImpactEntry[];
 };
 
 export type AvtaleGiroAgreement = {


### PR DESCRIPTION
DK sends impact data directly in the response of `/donors/0/donations/`, so here we skip calling a dedicated impact API endpoint, and instead just pass the data in the expected format.

Should have no effect on NO/SE behavior.