### PR TITLE
DK min side: fetch org description & link from organizations API

### DIFF
--- a/components/main/blocks/FundraiserWidget/panes/PaymentMethodPane.tsx
+++ b/components/main/blocks/FundraiserWidget/panes/PaymentMethodPane.tsx
@@ -93,7 +93,6 @@ export const PaymentMethodPane = React.forwardRef<HTMLDivElement, PaymentMethodP
 
       // Format CPR input for Danish locale
       let valueToUse = value;
-      console.log("locale", locale);
       if (locale === "da-DK" && formData.taxDeduction) {
         const formattedValue = formatTinInput(value, { allowCvr: true });
         e.target.value = formattedValue;

--- a/components/profile/donations/DonationImpact/DonationImpact.tsx
+++ b/components/profile/donations/DonationImpact/DonationImpact.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from "react";
 import { Distribution, DistributionCauseArea, Donation } from "../../../../models";
+import { Organization } from "../../../shared/components/Widget/types/Organization";
 import style from "./DonationImpact.module.scss";
 import ghStyle from "./GlobalHealth/DonationImpactGlobalHealth.module.scss";
 import {
@@ -22,7 +23,8 @@ const DonationImpact: React.FC<{
   distribution: Distribution;
   timestamp: Date;
   configuration: DonationImpactItemsConfiguration;
-}> = ({ donation, distribution, timestamp, configuration }) => {
+  organizations: Organization[];
+}> = ({ donation, distribution, timestamp, configuration, organizations }) => {
   const [requiredPrecision, setRequiredPrecision] = useState(0);
   const updatePrecision = useCallback(
     (precision: number) => {
@@ -36,24 +38,33 @@ const DonationImpact: React.FC<{
       <div className={ghStyle.container}>
         <table className={ghStyle.wrapper} cellSpacing={0} data-cy="donation-impact-list">
           <tbody>
-            {donation.impact.map((entry, i) => (
-              <DonationImpactGlobalHealthItem
-                key={`${donation.id}-impact-${i}`}
-                orgAbriv=""
-                orgName={entry.recipient}
-                sumToOrg={entry.amount}
-                donationTimestamp={timestamp}
-                precision={requiredPrecision}
-                signalRequiredPrecision={updatePrecision}
-                configuration={configuration.impact_item_configuration}
-                preComputedImpact={{
-                  output: entry.count,
-                  shortDescription: entry.unit,
-                  longDescription: entry.description,
-                  linkSubject: entry.unit,
-                }}
-              />
-            ))}
+            {donation.impact.map((entry, i) => {
+              const matchedOrg = organizations.find((org) => org.name === entry.organization);
+              if (!matchedOrg) {
+                console.error(
+                  `No organization found matching DK impact organization "${entry.organization}"`,
+                );
+              }
+              return (
+                <DonationImpactGlobalHealthItem
+                  key={`${donation.id}-impact-${i}`}
+                  orgAbriv=""
+                  orgName={entry.recipient}
+                  sumToOrg={entry.amount}
+                  donationTimestamp={timestamp}
+                  precision={requiredPrecision}
+                  signalRequiredPrecision={updatePrecision}
+                  configuration={configuration.impact_item_configuration}
+                  preComputedImpact={{
+                    output: entry.count,
+                    shortDescription: entry.unit,
+                    longDescription: matchedOrg?.shortDescription ?? "",
+                    charityName: entry.recipient,
+                    orgUrl: matchedOrg?.informationUrl ?? "",
+                  }}
+                />
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
+++ b/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
@@ -58,7 +58,8 @@ export type PreComputedImpact = {
   output: number;
   shortDescription: string;
   longDescription: string;
-  linkSubject: string;
+  charityName: string;
+  orgUrl: string;
 };
 
 export const DonationImpactGlobalHealthItem: React.FC<{
@@ -134,16 +135,18 @@ export const DonationImpactGlobalHealthItem: React.FC<{
     shortDescription: string;
     longDescription: string;
     charityName: string;
-    linkSubject: string;
+    orgUrl: string;
   } | null = preComputedImpact
-    ? { ...preComputedImpact, charityName: orgName }
+    ? preComputedImpact
     : relevantEvaluation
     ? {
         output: sumToOrg / relevantEvaluation.converted_cost_per_output,
         shortDescription: relevantEvaluation.intervention.short_description,
         longDescription: relevantEvaluation.intervention.long_description,
         charityName: relevantEvaluation.charity.charity_name,
-        linkSubject: relevantEvaluation.charity.charity_name,
+        orgUrl: configuration.about_org_link_url_format_string
+          .replace("{{org}}", relevantEvaluation.charity.charity_name)
+          .replaceAll(" ", "_"),
       }
     : null;
 
@@ -257,11 +260,9 @@ export const DonationImpactGlobalHealthItem: React.FC<{
                       _key: "charity_description",
                       title: configuration.about_org_link_title_format_string.replace(
                         "{{org}}",
-                        resolvedImpact.linkSubject,
+                        resolvedImpact.charityName,
                       ),
-                      url: configuration.about_org_link_url_format_string
-                        .replace("{{org}}", resolvedImpact.linkSubject)
-                        .replaceAll(" ", "_"),
+                      url: resolvedImpact.orgUrl,
                       newtab: true,
                     },
                   ]}

--- a/components/profile/shared/lists/donationList/DonationDetails.tsx
+++ b/components/profile/shared/lists/donationList/DonationDetails.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import style from "./DonationDetails.module.scss";
 import { Distribution, Donation } from "../../../../../models";
+import { Organization } from "../../../../shared/components/Widget/types/Organization";
 import DonationImpact, {
   DonationImpactItemsConfiguration,
 } from "../../../donations/DonationImpact/DonationImpact";
@@ -24,7 +25,8 @@ export const DonationDetails: React.FC<{
   distribution: Distribution;
   timestamp: Date;
   configuration: DonationDetailsConfiguration;
-}> = ({ sum, donation, distribution, timestamp, configuration }) => {
+  organizations: Organization[];
+}> = ({ sum, donation, distribution, timestamp, configuration, organizations }) => {
   const [showImpactEstimateExplanation, setShowImpactEstimateExplanation] = useState(false);
 
   if (!distribution && !donation.impact?.length)
@@ -56,6 +58,7 @@ export const DonationDetails: React.FC<{
           distribution={distribution}
           timestamp={timestamp}
           configuration={configuration.impact_items_configuration}
+          organizations={organizations}
         />
       </div>
 

--- a/components/profile/shared/lists/donationList/DonationList.tsx
+++ b/components/profile/shared/lists/donationList/DonationList.tsx
@@ -1,5 +1,6 @@
 import { PortableText } from "@portabletext/react";
 import { Distribution, Donation, TaxUnit } from "../../../../../models";
+import { Organization } from "../../../../shared/components/Widget/types/Organization";
 import { onlyDate, thousandize } from "../../../../../util/formatting";
 import { ErrorMessage } from "../../ErrorMessage/ErrorMessage";
 import { GenericList } from "../GenericList";
@@ -29,6 +30,7 @@ export const DonationList: React.FC<{
   configuration: DonationsListConfiguration;
   detailsConfiguration?: DonationDetailsConfiguration;
   firstOpen: boolean;
+  organizations: Organization[];
 }> = ({
   donations,
   distributions,
@@ -37,6 +39,7 @@ export const DonationList: React.FC<{
   configuration,
   detailsConfiguration,
   firstOpen,
+  organizations,
 }) => {
   let taxDeductionText: ReactNode | undefined = undefined;
 
@@ -107,6 +110,7 @@ export const DonationList: React.FC<{
           distribution={distributions.get(donation.KID.trim()) as Distribution}
           timestamp={new Date(donation.timestamp)}
           configuration={detailsConfiguration}
+          organizations={organizations}
         />
       ) : (
         <ErrorMessage>Missing donation details configuration in Sanity</ErrorMessage>

--- a/components/shared/components/Widget/components/Widget.tsx
+++ b/components/shared/components/Widget/components/Widget.tsx
@@ -155,8 +155,6 @@ export const Widget = withStaticProps(
   const widget = data.result;
   const methods = data.result.methods;
 
-  console.log(methods);
-
   if (!methods) {
     throw new Error("No payment methods found");
   }

--- a/models.ts
+++ b/models.ts
@@ -11,7 +11,7 @@ export type DonationImpactEntry = {
   unit: string;
   amount: number;
   count: number;
-  description: string;
+  organization: string;
 };
 
 export type Donation = {

--- a/pages/dashboard/DonationsPage.tsx
+++ b/pages/dashboard/DonationsPage.tsx
@@ -294,6 +294,7 @@ export const DonationsPage = withStaticProps(
         configuration={tableConfiguration}
         detailsConfiguration={page.donations_details_configuration}
         firstOpen={false}
+        organizations={organizations}
       />
     ) : (
       <ErrorMessage>
@@ -391,6 +392,7 @@ export const DonationsPage = withStaticProps(
             configuration={tableConfiguration}
             detailsConfiguration={page.donations_details_configuration}
             firstOpen={false}
+            organizations={organizations}
           />
         ) : (
           <ErrorMessage key={year}>
@@ -419,6 +421,7 @@ export const DonationsPage = withStaticProps(
         configuration={tableConfiguration}
         detailsConfiguration={page.donations_details_configuration}
         firstOpen={false}
+        organizations={organizations}
       />
     );
   }


### PR DESCRIPTION
Allows us to simply show the exact same description & urls on impact table as in donation widget, fetching data from the exact same `/organizations/all/` endpoint.

Should have no effect on NO/SE.