### PR TITLE
Ensure mobile navbar respects viewport and safe-area insets

### DIFF
--- a/components/shared/components/Navbar/Navbar.module.scss
+++ b/components/shared/components/Navbar/Navbar.module.scss
@@ -123,6 +123,8 @@
     top: 0;
     left: 0;
     width: 100%;
+    height: calc(100vh - var(--header-active-general-banner-height, 0px));
+    height: calc(100svh - var(--header-active-general-banner-height, 0px));
     height: calc(100dvh - var(--header-active-general-banner-height, 0px));
     touch-action: none;
   }
@@ -165,7 +167,7 @@
     font-weight: normal;
     display: flex;
     flex-direction: column;
-    padding-bottom: 2rem;
+    padding-bottom: calc(2rem + env(safe-area-inset-bottom, 0px));
     padding-top: 0.5rem;
   }
 
@@ -247,6 +249,7 @@
 
   .navbar ul li.buttonsWrapper {
     padding-top: 1.5rem;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
     margin-left: 0;
     align-self: flex-start;
     display: flex;


### PR DESCRIPTION
### Motivation
- Mobile menu action buttons (profile/donate) were partly obscured on some phones because the expanded menu did not reliably match the visible browser viewport or account for device safe-area insets.

### Description
- Update `components/shared/components/Navbar/Navbar.module.scss` to set the expanded mobile navbar height using layered viewport fallbacks (`calc(100vh - ...)`, `calc(100svh - ...)`, `calc(100dvh - ...)`) and add safe-area-aware bottom padding via `env(safe-area-inset-bottom, 0px)` for the menu list and the `.buttonsWrapper` so action buttons remain visible above OS/browser UI.

### Testing
- Ran `git diff --check` which succeeded, and ran `npm run lint -- components/shared/components/Navbar/Navbar.tsx` which failed due to existing repo-wide ESLint violations unrelated to this styling-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eb6dd81d2c8321842fd548afc3c9ba)