### PR TITLE
fix: mobile menu layout, horizontal scroll and Give button visibility

### DIFF
--- a/components/main/layout/GiveButton/GiveButton.module.scss
+++ b/components/main/layout/GiveButton/GiveButton.module.scss
@@ -2,18 +2,18 @@
   cursor: pointer;
   position: fixed;
   right: 5vw;
-  bottom: 60px;
-  z-index: 100;
+  bottom: calc(60px + var(--cookie-banner-height, 0px));
+  z-index: 1003;
   background: var(--accent-color, var(--primary));
   border: 1px solid var(--accent-color, var(--secondary));
-  font-size: 43px;
+  font-size: 64px;
   font-family: "ESKlarheitKurrent";
   font-weight: 400;
   color: var(--secondary);
   border-radius: 50%;
   user-select: none;
-  width: 100px;
-  height: 100px;
+  width: 150px;
+  height: 150px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -50,9 +50,9 @@
 
 @media only screen and (max-width: 1180px) {
   .givebutton {
-    font-size: 16px;
-    width: 50px;
-    height: 50px;
+    font-size: 48px;
+    width: 150px;
+    height: 150px;
   }
 }
 

--- a/components/main/layout/GiveButton/GiveButton.module.scss
+++ b/components/main/layout/GiveButton/GiveButton.module.scss
@@ -6,14 +6,14 @@
   z-index: 1003;
   background: var(--accent-color, var(--primary));
   border: 1px solid var(--accent-color, var(--secondary));
-  font-size: 64px;
+  font-size: 43px;
   font-family: "ESKlarheitKurrent";
   font-weight: 400;
   color: var(--secondary);
   border-radius: 50%;
   user-select: none;
-  width: 150px;
-  height: 150px;
+  width: 100px;
+  height: 100px;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -49,10 +49,8 @@
 }
 
 @media only screen and (max-width: 1180px) {
-  .givebutton {
-    font-size: 48px;
-    width: 150px;
-    height: 150px;
+  body:has([data-mobile-menu-expanded="true"]) .givebutton {
+    display: none;
   }
 }
 

--- a/components/shared/components/Navbar/Navbar.module.scss
+++ b/components/shared/components/Navbar/Navbar.module.scss
@@ -133,7 +133,9 @@
     justify-content: flex-start;
     height: auto;
     height: 100%;
-    overflow: scroll;
+    overflow-x: hidden;
+    overflow-y: auto;
+    padding-bottom: calc(var(--cookie-banner-height, 0px) + 1rem);
   }
 
   .expandBtn {
@@ -214,6 +216,7 @@
     font-size: 1rem;
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
+    white-space: normal;
   }
 
   .navbarExpanded ul li .submenu ul li a {
@@ -248,19 +251,22 @@
   .navbar ul li.buttonsWrapper {
     padding-top: 1.5rem;
     margin-left: 0;
-    align-self: flex-start;
+    align-self: stretch;
     display: flex;
-    flex-direction: row;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 0.75rem;
     width: 100%;
-    margin-top: auto;
   }
 
   .navbar ul li.buttonsWrapper a {
-    width: auto;
+    width: 100%;
   }
 
-  .navbar ul li.buttonsWrapper button:first-child {
+  .navbar ul li.buttonsWrapper button {
+    font-size: 1.125rem;
+    min-height: 52px;
+    padding: 14px 28px;
+    width: 100%;
     margin-left: 0;
   }
 

--- a/components/shared/components/Navbar/Navbar.module.scss
+++ b/components/shared/components/Navbar/Navbar.module.scss
@@ -135,7 +135,7 @@
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
-    padding-bottom: calc(var(--cookie-banner-height, 0px) + 1rem);
+    padding-bottom: calc(var(--cookie-banner-height, 0px) + 2rem);
   }
 
   .expandBtn {
@@ -256,6 +256,7 @@
     flex-direction: column;
     gap: 0.75rem;
     width: 100%;
+    margin-top: auto;
   }
 
   .navbar ul li.buttonsWrapper a {

--- a/components/shared/layout/CookieBanner/CookieBanner.tsx
+++ b/components/shared/layout/CookieBanner/CookieBanner.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext, useEffect, useRef, useState } from "react";
 import { GoogleAnalytics } from "../GoogleAnalytics";
 import { GoogleTagManager } from "../GoogleTagManager";
 import styles from "./CookieBanner.module.scss";
@@ -15,6 +15,7 @@ export const CookieBanner: React.FC<{
 }> = ({ configuration }) => {
   const [bannerContext, setBannerContext] = useContext(BannerContext);
   const [tracking, setTracking] = useState(false);
+  const bannerRef = useRef<HTMLDivElement | null>(null);
 
   // check for plausible_ignore localstorage to disable plausible tracking
   useEffect(() => {
@@ -27,6 +28,27 @@ export const CookieBanner: React.FC<{
       }
     }
   }, []);
+
+  // Expose the banner height as a CSS variable so layout elements (e.g. the mobile menu)
+  // can reserve space and avoid being covered by the fixed banner.
+  useEffect(() => {
+    const root = document.documentElement;
+    const element = bannerRef.current;
+    if (!element) {
+      root.style.setProperty("--cookie-banner-height", "0px");
+      return;
+    }
+    const updateHeight = () => {
+      root.style.setProperty("--cookie-banner-height", `${element.offsetHeight}px`);
+    };
+    updateHeight();
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+      root.style.setProperty("--cookie-banner-height", "0px");
+    };
+  }, [bannerContext.consentState]);
 
   if (!configuration) return null;
   const gaMeasurementId = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
@@ -71,7 +93,7 @@ export const CookieBanner: React.FC<{
         </>
       )}
       {bannerContext.consentState === "undecided" && (
-        <div data-cy="cookiebanner-container" className={styles.container}>
+        <div data-cy="cookiebanner-container" className={styles.container} ref={bannerRef}>
           <div className={styles.content}>
             <div className={styles.description}>
               <span className={styles.title}>{configuration.title}</span>


### PR DESCRIPTION
## Summary
- Remove the always-visible horizontal scrollbar in the expanded mobile menu (`overflow: scroll` -> `overflow-x: hidden; overflow-y: auto`) and let submenu items wrap to avoid width overflow.
- Make the mobile menu footer buttons full width and larger, placed right after the last menu item.
- Keep the floating "Give" button visible above the cookie banner on both mobile and desktop, and enlarge it, it returns to its original position when the banner is dismissed.
- Expose the cookie banner height as the CSS variable `--cookie-banner-height` (via `ResizeObserver`) so layout elements can reserve space and are not covered by the fixed banner.

## Changes
- `components/shared/components/Navbar/Navbar.module.scss`
- `components/main/layout/GiveButton/GiveButton.module.scss`
- `components/shared/layout/CookieBanner/CookieBanner.tsx`

## Test plan
- [ ] Mobile (<=1180px): open the hamburger menu and confirm there is no horizontal scrollbar.
- [ ] Mobile: footer buttons are full width, larger, and appear right after the last menu item.
- [ ] Mobile and desktop: the floating "Give" button stays above the cookie banner and is readable.
- [ ] Dismiss the cookie banner and confirm the "Give" button returns to its original position.
- [ ] Desktop layout unchanged apart from the "Give" button.