### PR TITLE
fix: mobile header overflow when cookie banner is present

### DIFF
--- a/components/shared/components/Navbar/Navbar.module.scss
+++ b/components/shared/components/Navbar/Navbar.module.scss
@@ -135,6 +135,9 @@
     height: 100%;
     overflow-x: hidden;
     overflow-y: auto;
+  }
+
+  .navbarExpanded .navbar {
     padding-bottom: calc(var(--cookie-banner-height, 0px) + 2rem);
   }
 


### PR DESCRIPTION
## Summary
Follow-up to #1100. On mobile, with the cookie banner visible, the fixed header was growing downward and covering the top of the page content; the header only re-appeared once the user accepted or declined cookies.

The root cause was the `padding-bottom: calc(var(--cookie-banner-height, 0px) + 2rem)` rule added to `.navbar` in PR #1100. That padding is only needed when the mobile menu is open (so the footer buttons stay above the banner), but it was being applied in both states. While the menu was collapsed, the cookie banner variable still grew the `.navbar` element, which made the fixed header overflow.

This PR scopes the rule to `.navbarExpanded .navbar`, so the cookie banner clearance is only added when the mobile menu is actually open.

## Changes
- `components/shared/components/Navbar/Navbar.module.scss`

## Test plan
- [ ] Mobile (<=1180px), cookie banner visible, menu closed: header fully visible at the top, no page content cut off.
- [ ] Mobile, cookies dismissed, menu closed: same as above.
- [ ] Mobile, cookie banner visible, menu open: footer buttons ("Min side" / "Gi en donasjon") still sit above the cookie banner with ~2rem of clearance.
- [ ] Mobile, cookies dismissed, menu open: footer buttons sit ~2rem from the bottom of the menu.
- [ ] Desktop: no visible change; floating Ge button still sits above the cookie banner.
- [ ] Originally reproduced on iPhone 13 Pro Safari.