### PR TITLE
fix: mutate donor to make sure missingName-modal is closed

### DIFF
--- a/components/profile/_queries.ts
+++ b/components/profile/_queries.ts
@@ -21,6 +21,7 @@ export const saveDonor = async (data: Donor, user: User, token: string) => {
     if (response.status !== 200) {
       return null;
     } else {
+      mutate(`/donors/${getUserId(user)}/`, donor, false);
       return donor;
     }
   } catch (e) {

--- a/components/profile/layout/MissingNameModal/MissingNameModal.tsx
+++ b/components/profile/layout/MissingNameModal/MissingNameModal.tsx
@@ -41,7 +41,7 @@ export const MissingNameModal: React.FC<{ config: MissingNameModalConfig }> = ({
         failureToast(config.failure_message);
       } else {
         successToast(config.success_message);
-        setDonor(updatedDonor);
+        setDonor(result);
         setOpen(false);
       }
     } else {


### PR DESCRIPTION
_Issue description here_
The missing name modal is not closed even though it successfully calls the APIe. Looks like the local state is not updated.

- closes #linked-issue-nr

---

Tested on devices

- [ ] Desktop 💻
- [ ] Mobile 📱

Tests

- [ ] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [ ] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
