### PR TITLE
Html embed with parse

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,24 @@
+# Norwegian dev project and dataset
 NEXT_PUBLIC_SANITY_PROJECT_ID=vf0df6h3
 NEXT_PUBLIC_SANITY_DATASET=dev
 SANITY_STUDIO_API_PROJECT_ID=vf0df6h3
 SANITY_STUDIO_API_DATASET=dev
 
+# Swedish production project and dataset
+# NEXT_PUBLIC_SANITY_PROJECT_ID=9reyurp9
+# NEXT_PUBLIC_SANITY_DATASET=production
+# SANITY_STUDIO_API_PROJECT_ID=9reyurp9
+# SANITY_STUDIO_API_DATASET=production
+
+# Local API
 NEXT_PUBLIC_EFFEKT_API=http://localhost:5050
 SANITY_STUDIO_EFFEKT_API_URL=http://localhost:5050
+
+# Swedish production API
+# NEXT_PUBLIC_EFFEKT_API=https://api.geeffektivt.se
+# SANITY_STUDIO_EFFEKT_API_URL=https://api.geeffektivt.se
+
+# Danish dev API
 # NEXT_PUBLIC_EFFEKT_API=https://dev-api.giveffektivt.dk
 # SANITY_STUDIO_EFFEKT_API_URL=https://dev-api.giveffektivt.dk
 
@@ -15,6 +29,13 @@ NEXT_PUBLIC_AUTH_DOMAIN=gieffektivt.eu.auth0.com
 NEXT_PUBLIC_AUTH_CLIENT_ID=y70pumEKFogcX8wK28Fhmun0tlPx6q7B
 NEXT_PUBLIC_AUTH_AUDIENCE=https://data.gieffektivt.no
 NEXT_PUBLIC_AUTH_USER_ID_CLAIM=https://gieffektivt.no/user-id
+
+# Swedish auth
+# NEXT_PUBLIC_AUTH_DOMAIN=gieffektivt.eu.auth0.com
+# NEXT_PUBLIC_AUTH_CLIENT_ID=y70pumEKFogcX8wK28Fhmun0tlPx6q7B
+# NEXT_PUBLIC_AUTH_AUDIENCE=https://api.geeffektivt.se
+# NEXT_PUBLIC_AUTH_USER_ID_CLAIM=https://geeffektivt.se/user-id
+
 
 # CYPRESS_BASE_URL=http://localhost:3000
 # CYPRESS_AUTH_DOMAIN=gieffektivt.eu.auth0.com

--- a/components/main/blocks/SplitViewHtml/SplitViewHtml.tsx
+++ b/components/main/blocks/SplitViewHtml/SplitViewHtml.tsx
@@ -6,6 +6,7 @@ import { Links } from "../Links/Links";
 import { PortableText } from "@portabletext/react";
 import { customComponentRenderers } from "../Paragraph/Citation";
 import { FundraiserVippsNumberDisplay } from "./FundraiserVippsNumberDisplay";
+import parse from "html-react-parser";
 
 export const SplitViewHtml: React.FC<{
   title: string;
@@ -46,7 +47,7 @@ export const SplitViewHtml: React.FC<{
         {links && <Links links={links} />}
       </div>
       <div className={styles.splitviewcode}>
-        <div dangerouslySetInnerHTML={{ __html: code }}></div>
+        <div>{parse(code)}</div>
         {adoveoFundraiserId && vippsNumber && (
           <FundraiserVippsNumberDisplay
             fundraiserId={adoveoFundraiserId}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "babel-jest": "^29.7.0",
         "cookies-next": "^4.3.0",
         "d3": "^7.8.2",
+        "html-react-parser": "^6.1.3",
         "jwt-decode": "^3.1.2",
         "katex": "^0.16.10",
         "luxon": "^3.4.4",
@@ -19315,6 +19316,53 @@
       "integrity": "sha512-C++tTF1GqkGYecL+2S1wJTfoH6APGAsbb7PAWQ3iVIwgG/EFseAfEVOKFgAFq4yK3+6j1EjUD4UQ9dRJHX/sSQ==",
       "license": "ISC"
     },
+    "node_modules/html-dom-parser": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-8.0.0.tgz",
+      "integrity": "sha512-cWLJ8mt930VceOzVfY/J+T1ou9v3ENT0BgWqy5aEZjdFp37TYLXULjX8u0vD2rBpFAkK5IofOPl0y4Gq0QLIyA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "6.0.1",
+        "htmlparser2": "12.0.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -19343,6 +19391,169 @@
       "peer": true,
       "dependencies": {
         "void-elements": "3.1.0"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-6.1.3.tgz",
+      "integrity": "sha512-CTsKtLJA23cgTbcJYT8vgHAPSqGY7NM+/mv+Tv6I0DqkLCa3FlceK2htH8AwlGa03BopqnVvK/XHqQq7HAw/sg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/remarkablemark"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/html-react-parser"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "6.0.1",
+        "html-dom-parser": "8.0.0",
+        "react-property": "2.0.2",
+        "style-to-js": "2.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": "0.14 || 15 || 16 || 17 || 18 || 19",
+        "react": "0.14 || 15 || 16 || 17 || 18 || 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/html-react-parser/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/html-react-parser/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -19615,6 +19826,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
     },
     "node_modules/internal-slot": {
       "version": "1.1.0",
@@ -24573,6 +24790,12 @@
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-property": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.2.tgz",
+      "integrity": "sha512-+PbtI3VuDV0l6CleQMsx2gtK0JZbZKbpdu5ynr+lbsuvtmgbNcS3VM0tuY2QjFNOcWxvXeHjDpy42RO+4U2rug==",
+      "license": "MIT"
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -27102,6 +27325,24 @@
       "integrity": "sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/style-to-js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-2.0.0.tgz",
+      "integrity": "sha512-amkl/SwHF/Gb430+eOiN+XToZ6VsD2nota1kCXps4k1xagZOniEVNm8zKYm7RrGm2Q6d6hjnZdqebFIunoSJng==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
     },
     "node_modules/styled-components": {
       "version": "6.3.11",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "babel-jest": "^29.7.0",
     "cookies-next": "^4.3.0",
     "d3": "^7.8.2",
+    "html-react-parser": "^6.1.3",
     "jwt-decode": "^3.1.2",
     "katex": "^0.16.10",
     "luxon": "^3.4.4",


### PR DESCRIPTION
Replaces danegrouslySetInnerHTML with a [library](https://github.com/remarkablemark/html-react-parser) that parses the raw HTML in to React components.

There are 9 uses of dangerouslySetInnerHTML but this only replaces the on required for the swedish TLYCS-page.

- closes #linked-issue-nr
https://app.asana.com/1/1207796269314443/project/1210857084074030/task/1213564948070401?focus=true

---

Tested on devices

- [x] Desktop 💻
- [x] Mobile 📱

Tests

- [x] All tests are running ✔️
- [ ] Test are updated 🧪
- [ ] Code Review 👩‍💻
- [ ] QA 👌

Checkpoints

_Check these to flag for a more thurough review, as they could be potentially breaking changes_

- [x] Packages updated
- [ ] Other infrastructure updated (such as node version or similar)

⏲️ Time spent on CR:

⏲️ Time spent on QA:
