### PR TITLE
fix: transpile html-react-parser to avoid ERR_REQUIRE_ESM on Vercel

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,11 @@ const STUDIO_REWRITE = {
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   productionBrowserSourceMaps: true,
+  // html-react-parser pulls in the ESM-only domhandler, which html-dom-parser
+  // loads via require(). Transpiling these packages forces Next to bundle them
+  // instead of leaving them as external runtime requires (which throws
+  // ERR_REQUIRE_ESM on the server/Vercel).
+  transpilePackages: ["html-react-parser", "html-dom-parser", "domhandler"],
   rewrites: async () => [STUDIO_REWRITE],
   images: {
     remotePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,6 +6882,17 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@sanity/cli-core/node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@sanity/cli-core/node_modules/configstore": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -7279,6 +7290,23 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/cli-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@sanity/cli/node_modules/find-up": {
@@ -8047,6 +8075,17 @@
         "node": ">=20.19"
       }
     },
+    "node_modules/@sanity/runtime-cli/node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@sanity/runtime-cli/node_modules/eventsource": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
@@ -8235,6 +8274,23 @@
       },
       "peerDependencies": {
         "vite": "*"
+      }
+    },
+    "node_modules/@sanity/runtime-cli/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@sanity/schema": {
@@ -26036,6 +26092,17 @@
         "node": ">=20.19 <22 || >=22.12"
       }
     },
+    "node_modules/sanity/node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/sanity/node_modules/@types/use-sync-external-store": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
@@ -26374,6 +26441,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/sanity/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/sass": {
@@ -28462,6 +28546,14 @@
         "node": ">=18.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -28896,6 +28988,17 @@
         "url": "https://opencollective.com/antfu"
       }
     },
+    "node_modules/vite-node/node_modules/@types/node": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
+      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/vite-node/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -29029,6 +29132,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/void-elements": {


### PR DESCRIPTION
## Problem

Sanity presentation mode crashes on Vercel with:

```
Error: Failed to load external module html-react-parser-...: ERR_REQUIRE_ESM:
require() of ES Module .../html-dom-parser/node_modules/domhandler/dist/index.js
... not supported.
  page: '/undecided/static/manifest.webmanifest'
```

## Root cause

`html-react-parser@6` depends on `html-dom-parser@8`, whose server module does a plain `require("domhandler")`. That resolves to the **ESM-only** `domhandler@6` (`"type": "module"`). When Turbopack **externalizes** the package, its runtime `externalImport` loads it with require semantics that reject ESM → `ERR_REQUIRE_ESM`.

It doesn't reproduce locally because Node 22.18 has `require(esm)` enabled; the failure comes from Turbopack's external loader, not Node's native require.

## Fix

Add `html-react-parser`, `html-dom-parser`, and `domhandler` to `transpilePackages`, forcing Next to **bundle** them instead of externalizing, so the ESM dependency is handled normally.

## Notes / verification

- Kept on `html-react-parser@6` (latest). The alternative was downgrading to v5, which uses the CJS-safe `domhandler@5` — but v6 added nothing but the domhandler bump, so this keeps us current without the interop break.
- A full local `next build` requires Sanity build-time env/data that isn't available locally, so this hasn't been verified end-to-end. **Please confirm against a Vercel preview** (the failing route was the generated `manifest.webmanifest`) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)