### PR TITLE
fix(impact): use grant cost-per-output for smart distribution outputs

### DIFF
--- a/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactGlobalHealth.tsx
+++ b/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactGlobalHealth.tsx
@@ -17,7 +17,16 @@ export type DonationImpactItemsConfiguration = {
   impact_item_configuration: ImpactItemConfiguration;
 };
 
-type DistributionEntry = { org: string; orgName: string; sum: number };
+type DistributionEntry = {
+  org: string;
+  orgName: string;
+  sum: number;
+  // The portion of `sum` that was routed via a GiveWell grant (smart distribution)
+  smartDistributionSum?: number;
+  // Outputs purchased by that grant portion, derived directly from the grant's
+  // own cost-per-output rather than the generic evaluation estimate
+  smartDistributionOutput?: number;
+};
 
 const DonationImpactGlobalHealth: React.FC<{
   donation: Donation;
@@ -85,11 +94,24 @@ const DonationImpactGlobalHealth: React.FC<{
       const org = allotment.charity.abbreviation;
       const orgName = allotment.charity.charity_name ?? allotment.charity.abbreviation;
       const sum = Math.round((allotment.sum_in_cents / grantTotal) * giveWellDist.sum);
+      // Outputs bought by this grant portion, using the grant's own cost-per-output
+      const output =
+        allotment.converted_cost_per_output > 0 ? sum / allotment.converted_cost_per_output : 0;
       const orgIndex = spreadDistribution.findIndex((d) => d.org === org);
       if (orgIndex !== -1) {
         spreadDistribution[orgIndex].sum += sum;
+        spreadDistribution[orgIndex].smartDistributionSum =
+          (spreadDistribution[orgIndex].smartDistributionSum ?? 0) + sum;
+        spreadDistribution[orgIndex].smartDistributionOutput =
+          (spreadDistribution[orgIndex].smartDistributionOutput ?? 0) + output;
       } else {
-        spreadDistribution.push({ org, orgName, sum });
+        spreadDistribution.push({
+          org,
+          orgName,
+          sum,
+          smartDistributionSum: sum,
+          smartDistributionOutput: output,
+        });
       }
     });
   }
@@ -105,6 +127,8 @@ const DonationImpactGlobalHealth: React.FC<{
                   orgAbriv={dist.org}
                   orgName={dist.orgName ?? dist.org}
                   sumToOrg={dist.sum}
+                  smartDistributionSum={dist.smartDistributionSum}
+                  smartDistributionOutput={dist.smartDistributionOutput}
                   donationTimestamp={timestamp}
                   precision={requiredPrecision}
                   signalRequiredPrecision={(precision) => {

--- a/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactGlobalHealth.tsx
+++ b/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactGlobalHealth.tsx
@@ -21,10 +21,9 @@ type DistributionEntry = {
   org: string;
   orgName: string;
   sum: number;
-  // The portion of `sum` that was routed via a GiveWell grant (smart distribution)
+  // Portion of `sum` routed via a GiveWell grant, and the outputs it bought
+  // using the grant's own cost-per-output
   smartDistributionSum?: number;
-  // Outputs purchased by that grant portion, derived directly from the grant's
-  // own cost-per-output rather than the generic evaluation estimate
   smartDistributionOutput?: number;
 };
 
@@ -94,7 +93,6 @@ const DonationImpactGlobalHealth: React.FC<{
       const org = allotment.charity.abbreviation;
       const orgName = allotment.charity.charity_name ?? allotment.charity.abbreviation;
       const sum = Math.round((allotment.sum_in_cents / grantTotal) * giveWellDist.sum);
-      // Outputs bought by this grant portion, using the grant's own cost-per-output
       const output =
         allotment.converted_cost_per_output > 0 ? sum / allotment.converted_cost_per_output : 0;
       const orgIndex = spreadDistribution.findIndex((d) => d.org === org);

--- a/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
+++ b/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
@@ -66,6 +66,11 @@ export const DonationImpactGlobalHealthItem: React.FC<{
   orgAbriv: string;
   orgName: string;
   sumToOrg: number;
+  // The portion of `sumToOrg` routed via a GiveWell grant (smart distribution)
+  smartDistributionSum?: number;
+  // Outputs bought by that grant portion, derived directly from the grant's own
+  // cost-per-output rather than the generic evaluation estimate
+  smartDistributionOutput?: number;
   donationTimestamp: Date;
   precision: number;
   signalRequiredPrecision: (precision: number) => void;
@@ -75,6 +80,8 @@ export const DonationImpactGlobalHealthItem: React.FC<{
   orgAbriv,
   orgName,
   sumToOrg,
+  smartDistributionSum,
+  smartDistributionOutput,
   donationTimestamp,
   precision,
   signalRequiredPrecision,
@@ -130,6 +137,11 @@ export const DonationImpactGlobalHealthItem: React.FC<{
    * This will be the most recent relevant evaluation to calculate the impact
    */
   const relevantEvaluation = data?.evaluations[0];
+  // The grant (smart distribution) portion uses outputs derived directly from
+  // the grant's own cost-per-output; the remaining direct portion still uses the
+  // most relevant evaluation estimate.
+  const grantOutput = smartDistributionOutput ?? 0;
+  const directSum = sumToOrg - (smartDistributionSum ?? 0);
   const resolvedImpact: {
     output: number;
     shortDescription: string;
@@ -140,7 +152,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
     ? preComputedImpact
     : relevantEvaluation
     ? {
-        output: sumToOrg / relevantEvaluation.converted_cost_per_output,
+        output: grantOutput + directSum / relevantEvaluation.converted_cost_per_output,
         shortDescription: relevantEvaluation.intervention.short_description,
         longDescription: relevantEvaluation.intervention.long_description,
         charityName: relevantEvaluation.charity.charity_name,

--- a/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
+++ b/components/profile/donations/DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx
@@ -66,10 +66,9 @@ export const DonationImpactGlobalHealthItem: React.FC<{
   orgAbriv: string;
   orgName: string;
   sumToOrg: number;
-  // The portion of `sumToOrg` routed via a GiveWell grant (smart distribution)
+  // Portion of `sumToOrg` routed via a GiveWell grant, and the outputs it bought
+  // using the grant's own cost-per-output
   smartDistributionSum?: number;
-  // Outputs bought by that grant portion, derived directly from the grant's own
-  // cost-per-output rather than the generic evaluation estimate
   smartDistributionOutput?: number;
   donationTimestamp: Date;
   precision: number;
@@ -137,9 +136,7 @@ export const DonationImpactGlobalHealthItem: React.FC<{
    * This will be the most recent relevant evaluation to calculate the impact
    */
   const relevantEvaluation = data?.evaluations[0];
-  // The grant (smart distribution) portion uses outputs derived directly from
-  // the grant's own cost-per-output; the remaining direct portion still uses the
-  // most relevant evaluation estimate.
+  // Grant portion uses grant-derived outputs; the direct portion uses the evaluation.
   const grantOutput = smartDistributionOutput ?? 0;
   const directSum = sumToOrg - (smartDistributionSum ?? 0);
   const resolvedImpact: {

--- a/components/profile/donations/DonationsAggregateImpactTable/_util.test.ts
+++ b/components/profile/donations/DonationsAggregateImpactTable/_util.test.ts
@@ -1,0 +1,302 @@
+import {
+  Distribution,
+  Donation,
+  GiveWellGrant,
+  ImpactCharity,
+  ImpactEvaluation,
+  META_OWNER,
+} from "../../../../models";
+import { aggregateImpact, aggregateOrgSumByYearAndMonth } from "./_util";
+
+/**
+ * These tests focus on the core behaviour of the impact calculation: money that
+ * is routed via a GiveWell grant (smart distribution) must derive its outputs
+ * from the grant's own cost-per-output, while direct/custom donations continue
+ * to use the generic evaluation estimate.
+ */
+
+const GIVEWELL_TOP_CHARITIES_FUND_ID = 12;
+
+const AMF: ImpactCharity = {
+  id: 1,
+  charity_name: "Against Malaria Foundation",
+  abbreviation: "AMF",
+};
+const MC: ImpactCharity = { id: 10, charity_name: "Malaria Consortium", abbreviation: "MC" };
+
+const buildDonation = (
+  overrides: Partial<Donation> & Pick<Donation, "KID" | "sum" | "timestamp">,
+): Donation => ({
+  donor: "Test Donor",
+  donorId: 1,
+  email: "test@example.com",
+  id: 1,
+  paymentMethod: "bank",
+  transactionCost: "0",
+  metaOwnerId: META_OWNER.EFFEKT,
+  ...overrides,
+});
+
+const buildDistribution = (
+  kid: string,
+  organizations: { id: number; name: string; percentageShare: string }[],
+  causeAreaShare = "100",
+): Distribution => ({
+  kid,
+  donorId: 1,
+  taxUnitId: null,
+  causeAreas: [
+    {
+      id: 1,
+      name: "Global Health",
+      standardSplit: false,
+      percentageShare: causeAreaShare,
+      organizations,
+    },
+  ],
+});
+
+const buildEvaluation = (
+  charity: ImpactCharity,
+  shortDescription: string,
+  convertedCostPerOutput: number,
+): ImpactEvaluation => ({
+  id: charity.id,
+  intervention: {
+    long_description: `${shortDescription} long`,
+    short_description: shortDescription,
+    id: charity.id,
+  },
+  converted_cost_per_output: convertedCostPerOutput,
+  currency: "NOK",
+  language: "no",
+  start_year: 2024,
+  start_month: 1,
+  cents_per_output: 0,
+  charity,
+});
+
+// A grant where the grant's OWN cost-per-output deliberately differs from the
+// evaluations below, so we can prove which source is used.
+const buildGrant = (): GiveWellGrant => ({
+  id: 1,
+  language: "no",
+  start_year: 2024,
+  start_month: 0,
+  allotment_set: [
+    {
+      id: 1,
+      intervention: { long_description: "Bednets long", short_description: "Bednets", id: 1 },
+      converted_sum: 0,
+      currency: "NOK",
+      converted_cost_per_output: 50, // grant cost for AMF
+      exchange_rate_date: "2024-01-01",
+      sum_in_cents: 6000, // 60% of the grant
+      number_outputs_purchased: 0,
+      charity: AMF,
+    },
+    {
+      id: 2,
+      intervention: {
+        long_description: "Malaria treatments long",
+        short_description: "Malaria treatments",
+        id: 2,
+      },
+      converted_sum: 0,
+      currency: "NOK",
+      converted_cost_per_output: 200, // grant cost for MC
+      exchange_rate_date: "2024-01-01",
+      sum_in_cents: 4000, // 40% of the grant
+      number_outputs_purchased: 0,
+      charity: MC,
+    },
+  ],
+});
+
+const templateStrings = {
+  org_grant_template_string: "{{org}} via fond",
+  org_direct_template_string: "{{org}} direkte",
+};
+
+describe("aggregateOrgSumByYearAndMonth", () => {
+  it("returns an empty aggregate when there are no grants", () => {
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          {
+            id: GIVEWELL_TOP_CHARITIES_FUND_ID,
+            name: "GiveWell Top Charities Fund",
+            percentageShare: "100",
+          },
+        ]),
+      ],
+    ]);
+
+    expect(aggregateOrgSumByYearAndMonth([donation], distributions, null)).toEqual({});
+  });
+
+  it("splits smart distribution across allotments and derives outputs from the grant cost-per-output", () => {
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          {
+            id: GIVEWELL_TOP_CHARITIES_FUND_ID,
+            name: "GiveWell Top Charities Fund",
+            percentageShare: "100",
+          },
+        ]),
+      ],
+    ]);
+
+    const aggregated = aggregateOrgSumByYearAndMonth([donation], distributions, [buildGrant()]);
+
+    // AMF gets 60% of 1000 = 600 kr via the grant -> 600 / 50 = 12 outputs
+    expect(aggregated["Against Malaria Foundation"].smart_distribution_sum).toBe(600);
+    expect(aggregated["Against Malaria Foundation"].custom_sum).toBe(0);
+    expect(aggregated["Against Malaria Foundation"].smart_distribution_outputs).toBeCloseTo(12);
+
+    // MC gets 40% of 1000 = 400 kr via the grant -> 400 / 200 = 2 outputs
+    expect(aggregated["Malaria Consortium"].smart_distribution_sum).toBe(400);
+    expect(aggregated["Malaria Consortium"].smart_distribution_outputs).toBeCloseTo(2);
+  });
+
+  it("records direct donations as custom sums with no grant-derived outputs", () => {
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          { id: AMF.id, name: "Against Malaria Foundation", percentageShare: "100" },
+        ]),
+      ],
+    ]);
+
+    const aggregated = aggregateOrgSumByYearAndMonth([donation], distributions, [buildGrant()]);
+
+    expect(aggregated["Against Malaria Foundation"].custom_sum).toBe(1000);
+    expect(aggregated["Against Malaria Foundation"].smart_distribution_sum).toBe(0);
+    expect(aggregated["Against Malaria Foundation"].smart_distribution_outputs).toBe(0);
+  });
+});
+
+describe("aggregateImpact", () => {
+  const evaluations = [
+    buildEvaluation(AMF, "Bednets", 100), // eval cost differs from grant (50)
+    buildEvaluation(MC, "Malaria treatments", 100), // eval cost differs from grant (200)
+  ];
+
+  it("uses the grant cost-per-output (not the evaluation) for smart distribution outputs", () => {
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          {
+            id: GIVEWELL_TOP_CHARITIES_FUND_ID,
+            name: "GiveWell Top Charities Fund",
+            percentageShare: "100",
+          },
+        ]),
+      ],
+    ]);
+
+    const aggregated = aggregateOrgSumByYearAndMonth([donation], distributions, [buildGrant()]);
+    const impact = aggregateImpact(aggregated, evaluations, templateStrings);
+
+    // Grant-derived: 600/50 = 12. Evaluation-derived would (incorrectly) be 600/100 = 6.
+    expect(impact["bednets"].outputs).toBeCloseTo(12);
+    expect(impact["bednets"].outputs).not.toBeCloseTo(6);
+
+    // Grant-derived: 400/200 = 2. Evaluation-derived would (incorrectly) be 400/100 = 4.
+    expect(impact["malaria treatments"].outputs).toBeCloseTo(2);
+    expect(impact["malaria treatments"].outputs).not.toBeCloseTo(4);
+
+    // Constituent kr amounts are attributed to the "via fond" label
+    expect(impact["bednets"].constituents["Against Malaria Foundation via fond"]).toBe(600);
+    expect(impact["malaria treatments"].constituents["Malaria Consortium via fond"]).toBe(400);
+  });
+
+  it("uses the evaluation cost-per-output for direct/custom donations", () => {
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          { id: AMF.id, name: "Against Malaria Foundation", percentageShare: "100" },
+        ]),
+      ],
+    ]);
+
+    const aggregated = aggregateOrgSumByYearAndMonth([donation], distributions, [buildGrant()]);
+    const impact = aggregateImpact(aggregated, evaluations, templateStrings);
+
+    // Direct donation: 1000 / 100 (eval cost) = 10 outputs
+    expect(impact["bednets"].outputs).toBeCloseTo(10);
+    expect(impact["bednets"].constituents["Against Malaria Foundation direkte"]).toBe(1000);
+  });
+
+  it("blends grant-derived and evaluation-derived outputs when an org gets both", () => {
+    // 50% direct to AMF, 50% to the GiveWell fund
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          { id: AMF.id, name: "Against Malaria Foundation", percentageShare: "50" },
+          {
+            id: GIVEWELL_TOP_CHARITIES_FUND_ID,
+            name: "GiveWell Top Charities Fund",
+            percentageShare: "50",
+          },
+        ]),
+      ],
+    ]);
+
+    const aggregated = aggregateOrgSumByYearAndMonth([donation], distributions, [buildGrant()]);
+    const impact = aggregateImpact(aggregated, evaluations, templateStrings);
+
+    // AMF direct: 500 kr / 100 (eval) = 5 outputs
+    // AMF via grant: 60% of 500 = 300 kr / 50 (grant) = 6 outputs
+    // Total = 11
+    expect(impact["bednets"].outputs).toBeCloseTo(11);
+    expect(impact["bednets"].constituents["Against Malaria Foundation direkte"]).toBe(500);
+    expect(impact["bednets"].constituents["Against Malaria Foundation via fond"]).toBe(300);
+
+    // MC via grant only: 40% of 500 = 200 kr / 200 (grant) = 1 output
+    expect(impact["malaria treatments"].outputs).toBeCloseTo(1);
+    expect(impact["malaria treatments"].constituents["Malaria Consortium via fond"]).toBe(200);
+  });
+
+  it("still reports smart distribution outputs even when the evaluation is stale relative to the grant", () => {
+    // The grant is from 2024/2025 but the only evaluation available is old; the
+    // smart distribution outputs must not depend on it.
+    const staleEvaluations = [
+      { ...buildEvaluation(AMF, "Bednets", 100), start_year: 2020, start_month: 1 },
+      { ...buildEvaluation(MC, "Malaria treatments", 100), start_year: 2020, start_month: 1 },
+    ];
+
+    const donation = buildDonation({ KID: "1", sum: "1000", timestamp: "2025-01-15" });
+    const distributions = new Map<string, Distribution>([
+      [
+        "1",
+        buildDistribution("1", [
+          {
+            id: GIVEWELL_TOP_CHARITIES_FUND_ID,
+            name: "GiveWell Top Charities Fund",
+            percentageShare: "100",
+          },
+        ]),
+      ],
+    ]);
+
+    const aggregated = aggregateOrgSumByYearAndMonth([donation], distributions, [buildGrant()]);
+    const impact = aggregateImpact(aggregated, staleEvaluations, templateStrings);
+
+    expect(impact["bednets"].outputs).toBeCloseTo(12);
+    expect(impact["malaria treatments"].outputs).toBeCloseTo(2);
+  });
+});

--- a/components/profile/donations/DonationsAggregateImpactTable/_util.ts
+++ b/components/profile/donations/DonationsAggregateImpactTable/_util.ts
@@ -9,12 +9,17 @@ export type OrganizationsAggregatedSums = {
     sum: number;
     custom_sum: number;
     smart_distribution_sum: number;
+    // Outputs purchased by the smart distribution (grant) portion, derived
+    // directly from the grant's own cost-per-output rather than the generic
+    // evaluation estimate
+    smart_distribution_outputs: number;
     periods: {
       // Period (year-month) sums
       [key: string]: {
         sum: number;
         custom_sum: number;
         smart_distribution_sum: number;
+        smart_distribution_outputs: number;
       };
     };
   };
@@ -105,6 +110,9 @@ export const aggregateOrgSumByYearAndMonth = (
                     allotmentShare,
                 },
                 true,
+                // Use the grant's own cost-per-output so the outputs reflect the
+                // actual grant rather than the generic cost-effectiveness estimate
+                allotment.converted_cost_per_output,
               );
             });
           }
@@ -146,6 +154,10 @@ const addToAggregated = (
   month: number,
   org: { name: string; percentageShare: number },
   smartdistribution: boolean,
+  // The grant's own cost-per-output, only provided for smart distribution
+  // (money routed via a GiveWell grant). Used to derive the outputs directly
+  // from the grant instead of the generic evaluation estimate.
+  grantCostPerOutput?: number,
 ) => {
   const key = `${year}-${month}`;
   // First check if the organization is already in the aggregated sums
@@ -156,6 +168,7 @@ const addToAggregated = (
       sum: 0,
       custom_sum: 0,
       smart_distribution_sum: 0,
+      smart_distribution_outputs: 0,
       periods: {},
     };
   }
@@ -168,32 +181,35 @@ const addToAggregated = (
       sum: 0,
       custom_sum: 0,
       smart_distribution_sum: 0,
+      smart_distribution_outputs: 0,
     };
   }
+
+  const amount = Math.round((org.percentageShare / 100) * parseFloat(donation.sum));
+
   // Add to the total sum of the organization, regardless of period
-  aggregated[org.name].sum += Math.round((org.percentageShare / 100) * parseFloat(donation.sum));
+  aggregated[org.name].sum += amount;
   // Add to the sum of the organization for the period
-  aggregated[org.name].periods[key].sum += Math.round(
-    (org.percentageShare / 100) * parseFloat(donation.sum),
-  );
+  aggregated[org.name].periods[key].sum += amount;
   if (smartdistribution) {
     // Add to the smart distribution sum of the organization, regardless of period
-    aggregated[org.name].smart_distribution_sum += Math.round(
-      (org.percentageShare / 100) * parseFloat(donation.sum),
-    );
+    aggregated[org.name].smart_distribution_sum += amount;
     // Add to the smart distribution sum of the organization for the period
-    aggregated[org.name].periods[key].smart_distribution_sum += Math.round(
-      (org.percentageShare / 100) * parseFloat(donation.sum),
-    );
+    aggregated[org.name].periods[key].smart_distribution_sum += amount;
+
+    // Derive the outputs purchased directly from the grant's cost-per-output.
+    // This reflects what the grant actually bought, rather than re-deriving it
+    // from the generic (and often stale) cost-effectiveness evaluation.
+    if (grantCostPerOutput && grantCostPerOutput > 0) {
+      const outputs = amount / grantCostPerOutput;
+      aggregated[org.name].smart_distribution_outputs += outputs;
+      aggregated[org.name].periods[key].smart_distribution_outputs += outputs;
+    }
   } else {
     // Add to the custom distribution sum of the organization, regardless of period
-    aggregated[org.name].custom_sum += Math.round(
-      (org.percentageShare / 100) * parseFloat(donation.sum),
-    );
+    aggregated[org.name].custom_sum += amount;
     // Add to the custom distribution sum of the organization for the period
-    aggregated[org.name].periods[key].custom_sum += Math.round(
-      (org.percentageShare / 100) * parseFloat(donation.sum),
-    );
+    aggregated[org.name].periods[key].custom_sum += amount;
   }
 
   return aggregated;
@@ -266,58 +282,62 @@ export const aggregateImpact = (
     Object.keys(aggregatedorganizations[orgkey].periods).forEach((period) => {
       const year = period.split("-")[0];
       const month = period.split("-")[1];
+      const periodData = aggregatedorganizations[orgkey].periods[period];
 
-      // Find the evaluation that matches the year and month
-      const evaluation = getRelevantEvaluation(filteredEvaluations, year, month);
+      // Smart distribution (money routed via a GiveWell grant) uses the outputs
+      // derived directly from the grant's own cost-per-output. This reflects
+      // what the grant actually purchased instead of re-deriving it from the
+      // generic cost-effectiveness evaluation.
+      impact[outputtype].outputs += periodData.smart_distribution_outputs;
 
-      if (evaluation) {
-        // Add the output to the total output
-        // Equal to the sum of the organization for the period,
-        // divided by cost of the intervention given by the most relevant evaluation for the given period
-        impact[outputtype].outputs +=
-          aggregatedorganizations[orgkey].periods[period].sum /
-          evaluation.converted_cost_per_output;
-
-        // Add the constituents to the output
-        // E.g. if the output is deworming treatments, and we've added 1000 treatments
-        // to the total output from a donation to "Deworming Charity",
-        // we add the kr amount to the constituent "Deworming Charity"
-        // Depending on wether the donation amount for the period came from a fund (e.g. GiveWell
-        // Top Charities Fund) or directly to the organization, we add the amount to the fund
-        // constituent or the direct constituent (or both)
-
-        const fundconstituentlabel = textTemplates.org_grant_template_string.replace(
-          "{{org}}",
-          orgkey,
-        );
-        //`${orgkey} via fond`;
-        const customconstituentlabel = textTemplates.org_direct_template_string.replace(
-          "{{org}}",
-          orgkey,
-        );
-        //`${orgkey} direkte fordelt`;
-
-        // The amount for the period and organization that was routed via a fund is above 0
-        // e.g. aggregatedorganizations["Deworming Charity"].periods["2021-1"].smart_distribution_sum is above 0
-        if (aggregatedorganizations[orgkey].periods[period].smart_distribution_sum > 0) {
-          if (!(fundconstituentlabel in impact[outputtype].constituents)) {
-            impact[outputtype].constituents[fundconstituentlabel] = 0;
-          }
-          impact[outputtype].constituents[fundconstituentlabel] +=
-            aggregatedorganizations[orgkey].periods[period].smart_distribution_sum;
+      // Custom / direct donations to the organization still use the most
+      // relevant evaluation estimate, since there is no grant to attribute them to.
+      if (periodData.custom_sum > 0) {
+        // Find the evaluation that matches the year and month
+        const evaluation = getRelevantEvaluation(filteredEvaluations, year, month);
+        if (evaluation) {
+          impact[outputtype].outputs +=
+            periodData.custom_sum / evaluation.converted_cost_per_output;
+        } else {
+          console.error("NO EVALUATION FOUND FOR", orgkey, period);
         }
+      }
 
-        // The amount for the period and organization that was custom distributed is above 0
-        // e.g. aggregatedorganizations["Deworming Charity"].periods["2021-1"].custom_distribution_sum is above 0
-        if (aggregatedorganizations[orgkey].periods[period].custom_sum > 0) {
-          if (!(customconstituentlabel in impact[outputtype].constituents)) {
-            impact[outputtype].constituents[customconstituentlabel] = 0;
-          }
-          impact[outputtype].constituents[customconstituentlabel] +=
-            aggregatedorganizations[orgkey].periods[period].custom_sum;
+      // Add the constituents to the output
+      // E.g. if the output is deworming treatments, and we've added 1000 treatments
+      // to the total output from a donation to "Deworming Charity",
+      // we add the kr amount to the constituent "Deworming Charity"
+      // Depending on wether the donation amount for the period came from a fund (e.g. GiveWell
+      // Top Charities Fund) or directly to the organization, we add the amount to the fund
+      // constituent or the direct constituent (or both)
+
+      const fundconstituentlabel = textTemplates.org_grant_template_string.replace(
+        "{{org}}",
+        orgkey,
+      );
+      //`${orgkey} via fond`;
+      const customconstituentlabel = textTemplates.org_direct_template_string.replace(
+        "{{org}}",
+        orgkey,
+      );
+      //`${orgkey} direkte fordelt`;
+
+      // The amount for the period and organization that was routed via a fund is above 0
+      // e.g. aggregatedorganizations["Deworming Charity"].periods["2021-1"].smart_distribution_sum is above 0
+      if (periodData.smart_distribution_sum > 0) {
+        if (!(fundconstituentlabel in impact[outputtype].constituents)) {
+          impact[outputtype].constituents[fundconstituentlabel] = 0;
         }
-      } else {
-        console.error("NO EVALUATION FOUND FOR", orgkey, period);
+        impact[outputtype].constituents[fundconstituentlabel] += periodData.smart_distribution_sum;
+      }
+
+      // The amount for the period and organization that was custom distributed is above 0
+      // e.g. aggregatedorganizations["Deworming Charity"].periods["2021-1"].custom_distribution_sum is above 0
+      if (periodData.custom_sum > 0) {
+        if (!(customconstituentlabel in impact[outputtype].constituents)) {
+          impact[outputtype].constituents[customconstituentlabel] = 0;
+        }
+        impact[outputtype].constituents[customconstituentlabel] += periodData.custom_sum;
       }
     });
   });

--- a/components/profile/donations/DonationsAggregateImpactTable/_util.ts
+++ b/components/profile/donations/DonationsAggregateImpactTable/_util.ts
@@ -9,9 +9,7 @@ export type OrganizationsAggregatedSums = {
     sum: number;
     custom_sum: number;
     smart_distribution_sum: number;
-    // Outputs purchased by the smart distribution (grant) portion, derived
-    // directly from the grant's own cost-per-output rather than the generic
-    // evaluation estimate
+    // Outputs derived from the grant's own cost-per-output (not the evaluation)
     smart_distribution_outputs: number;
     periods: {
       // Period (year-month) sums
@@ -110,8 +108,6 @@ export const aggregateOrgSumByYearAndMonth = (
                     allotmentShare,
                 },
                 true,
-                // Use the grant's own cost-per-output so the outputs reflect the
-                // actual grant rather than the generic cost-effectiveness estimate
                 allotment.converted_cost_per_output,
               );
             });
@@ -154,9 +150,7 @@ const addToAggregated = (
   month: number,
   org: { name: string; percentageShare: number },
   smartdistribution: boolean,
-  // The grant's own cost-per-output, only provided for smart distribution
-  // (money routed via a GiveWell grant). Used to derive the outputs directly
-  // from the grant instead of the generic evaluation estimate.
+  // Grant's own cost-per-output; only provided for smart distribution
   grantCostPerOutput?: number,
 ) => {
   const key = `${year}-${month}`;
@@ -197,9 +191,6 @@ const addToAggregated = (
     // Add to the smart distribution sum of the organization for the period
     aggregated[org.name].periods[key].smart_distribution_sum += amount;
 
-    // Derive the outputs purchased directly from the grant's cost-per-output.
-    // This reflects what the grant actually bought, rather than re-deriving it
-    // from the generic (and often stale) cost-effectiveness evaluation.
     if (grantCostPerOutput && grantCostPerOutput > 0) {
       const outputs = amount / grantCostPerOutput;
       aggregated[org.name].smart_distribution_outputs += outputs;
@@ -284,16 +275,11 @@ export const aggregateImpact = (
       const month = period.split("-")[1];
       const periodData = aggregatedorganizations[orgkey].periods[period];
 
-      // Smart distribution (money routed via a GiveWell grant) uses the outputs
-      // derived directly from the grant's own cost-per-output. This reflects
-      // what the grant actually purchased instead of re-deriving it from the
-      // generic cost-effectiveness evaluation.
+      // Smart distribution uses grant-derived outputs; direct donations fall
+      // back to the most relevant evaluation estimate.
       impact[outputtype].outputs += periodData.smart_distribution_outputs;
 
-      // Custom / direct donations to the organization still use the most
-      // relevant evaluation estimate, since there is no grant to attribute them to.
       if (periodData.custom_sum > 0) {
-        // Find the evaluation that matches the year and month
         const evaluation = getRelevantEvaluation(filteredEvaluations, year, month);
         if (evaluation) {
           impact[outputtype].outputs +=
@@ -303,27 +289,17 @@ export const aggregateImpact = (
         }
       }
 
-      // Add the constituents to the output
-      // E.g. if the output is deworming treatments, and we've added 1000 treatments
-      // to the total output from a donation to "Deworming Charity",
-      // we add the kr amount to the constituent "Deworming Charity"
-      // Depending on wether the donation amount for the period came from a fund (e.g. GiveWell
-      // Top Charities Fund) or directly to the organization, we add the amount to the fund
-      // constituent or the direct constituent (or both)
-
+      // Attribute the kr amounts to the "via fond" and/or "direkte" constituents
+      // so the row can be broken down by how the money reached the organization.
       const fundconstituentlabel = textTemplates.org_grant_template_string.replace(
         "{{org}}",
         orgkey,
       );
-      //`${orgkey} via fond`;
       const customconstituentlabel = textTemplates.org_direct_template_string.replace(
         "{{org}}",
         orgkey,
       );
-      //`${orgkey} direkte fordelt`;
 
-      // The amount for the period and organization that was routed via a fund is above 0
-      // e.g. aggregatedorganizations["Deworming Charity"].periods["2021-1"].smart_distribution_sum is above 0
       if (periodData.smart_distribution_sum > 0) {
         if (!(fundconstituentlabel in impact[outputtype].constituents)) {
           impact[outputtype].constituents[fundconstituentlabel] = 0;
@@ -331,8 +307,6 @@ export const aggregateImpact = (
         impact[outputtype].constituents[fundconstituentlabel] += periodData.smart_distribution_sum;
       }
 
-      // The amount for the period and organization that was custom distributed is above 0
-      // e.g. aggregatedorganizations["Deworming Charity"].periods["2021-1"].custom_distribution_sum is above 0
       if (periodData.custom_sum > 0) {
         if (!(customconstituentlabel in impact[outputtype].constituents)) {
           impact[outputtype].constituents[customconstituentlabel] = 0;

--- a/cypress/e2e/no/donations.js
+++ b/cypress/e2e/no/donations.js
@@ -92,10 +92,8 @@ describe("Donations page", () => {
 
     cy.fixture(`evaluations/evaluations.json`)
       .then((evaluations) => {
-        // NB: match any language/currency casing. The app requests language=no
-        // (lowercase), so a hardcoded language=NO here would never match and every
-        // evaluation request would silently fall through to the live impact API,
-        // making the impact assertions non-deterministic.
+        // Match any language/currency casing: the app sends language=no, so a
+        // hardcoded language=NO would miss and hit the live API instead.
         cy.intercept(
           "https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=*&currency=*&language=*&donation_year=*&donation_month=*",
           (req) => {
@@ -115,10 +113,8 @@ describe("Donations page", () => {
 
     cy.fixture("grants")
       .then((grants) => {
-        // Match every max_impact_fund_grants request. The aggregate impact table
-        // requests grants without donation_year/month params, so a stricter glob
-        // (e.g. requiring a trailing "&*") would let that request fall through to
-        // the live API and make the test non-deterministic.
+        // Match every grants request; the aggregate table fetches without
+        // donation_year/month params, which a stricter glob would miss.
         cy.intercept("GET", "https://impact.gieffektivt.no/api/max_impact_fund_grants*", {
           statusCode: 200,
           body: grants,
@@ -204,11 +200,9 @@ describe("Donations page", () => {
       .first()
       .should("contain.text", "dollar mottatt");
 
-    // The grants fixture is dated before the GiveWell-fund donations, so the money
-    // routed via the fund is smart-distributed and its outputs are derived from the
-    // grant's own cost-per-output. These values (18 malaria treatments and 16
-    // vaccinations) only come out right when the grant cost is used; deriving them
-    // from the generic evaluations instead yields 17 and 12.
+    // The grant fixture predates the GiveWell-fund donations, so the fund portion
+    // is smart-distributed using the grant's cost-per-output. These values only
+    // hold with the grant-based fix (evaluations alone would give 17 and 12).
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
       .eq(1)
       .should("contain.text", "18");

--- a/cypress/e2e/no/donations.js
+++ b/cypress/e2e/no/donations.js
@@ -92,8 +92,12 @@ describe("Donations page", () => {
 
     cy.fixture(`evaluations/evaluations.json`)
       .then((evaluations) => {
+        // NB: match any language/currency casing. The app requests language=no
+        // (lowercase), so a hardcoded language=NO here would never match and every
+        // evaluation request would silently fall through to the live impact API,
+        // making the impact assertions non-deterministic.
         cy.intercept(
-          "https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=*&currency=NOK&language=NO&donation_year=*&donation_month=*",
+          "https://impact.gieffektivt.no/api/evaluations?charity_abbreviation=*&currency=*&language=*&donation_year=*&donation_month=*",
           (req) => {
             const [, abbriv, year, month] = req.url.match(
               /.*abbreviation=(.*)\&currency.*year=(\d{4}).*month=(\d{1,2})/,
@@ -318,7 +322,7 @@ describe("Donations page", () => {
       .eq(0)
       .find("[data-cy=donation-impact-list-item-output]")
       .first()
-      .should("contain.text", "12,0");
+      .should("contain.text", "12,4");
 
     cy.get("[data-cy=generic-list-table]")
       .first()
@@ -329,7 +333,7 @@ describe("Donations page", () => {
       .eq(1)
       .find("[data-cy=donation-impact-list-item-output]")
       .first()
-      .should("contain.text", "20,0");
+      .should("contain.text", "20,2");
 
     cy.get("[data-cy=generic-list-table]")
       .first()

--- a/cypress/e2e/no/donations.js
+++ b/cypress/e2e/no/donations.js
@@ -200,9 +200,21 @@ describe("Donations page", () => {
       .first()
       .should("contain.text", "dollar mottatt");
 
+    // The grants fixture is dated before the GiveWell-fund donations, so the money
+    // routed via the fund is smart-distributed and its outputs are derived from the
+    // grant's own cost-per-output. These values (18 malaria treatments and 16
+    // vaccinations) only come out right when the grant cost is used; deriving them
+    // from the generic evaluations instead yields 17 and 12.
+    cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
+      .eq(1)
+      .should("contain.text", "18");
+    cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
+      .eq(1)
+      .should("contain.text", "malariabehandlinger");
+
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
       .last()
-      .should("contain.text", "12");
+      .should("contain.text", "16");
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
       .last()
       .should("contain.text", "vaksinasjoner");

--- a/cypress/e2e/no/donations.js
+++ b/cypress/e2e/no/donations.js
@@ -111,14 +111,14 @@ describe("Donations page", () => {
 
     cy.fixture("grants")
       .then((grants) => {
-        cy.intercept(
-          "GET",
-          "https://impact.gieffektivt.no/api/max_impact_fund_grants?currency=NOK&language=NO&*",
-          {
-            statusCode: 200,
-            body: grants,
-          },
-        ).as("getGrants");
+        // Match every max_impact_fund_grants request. The aggregate impact table
+        // requests grants without donation_year/month params, so a stricter glob
+        // (e.g. requiring a trailing "&*") would let that request fall through to
+        // the live API and make the test non-deterministic.
+        cy.intercept("GET", "https://impact.gieffektivt.no/api/max_impact_fund_grants*", {
+          statusCode: 200,
+          body: grants,
+        }).as("getGrants");
       })
       .as("grantsFixture");
 
@@ -192,13 +192,13 @@ describe("Donations page", () => {
   it("Should display a donation aggregate impact table", () => {
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]", {
       timeout: 15000,
-    }).should("have.length", 6);
+    }).should("have.length", 5);
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
       .first()
-      .should("contain.text", "118");
+      .should("contain.text", "1 049");
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
       .first()
-      .should("contain.text", "A-vitamintilskudd");
+      .should("contain.text", "dollar mottatt");
 
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]")
       .last()
@@ -220,7 +220,7 @@ describe("Donations page", () => {
 
     cy.get("[data-cy=donation-aggregate-impact-distribution-row]", {
       timeout: 15000,
-    }).should("have.length", 5);
+    }).should("have.length", 3);
     cy.get("[data-cy=aggregated-donation-totals]").should("contain.text", "I 2021");
     cy.get("[data-cy=aggregated-donation-totals]").should("contain.text", "108\u00A0574 kr");
   });

--- a/cypress/e2e/no/donations.js
+++ b/cypress/e2e/no/donations.js
@@ -322,7 +322,7 @@ describe("Donations page", () => {
       .eq(0)
       .find("[data-cy=donation-impact-list-item-output]")
       .first()
-      .should("contain.text", "12,4");
+      .should("contain.text", "12,0");
 
     cy.get("[data-cy=generic-list-table]")
       .first()
@@ -333,7 +333,7 @@ describe("Donations page", () => {
       .eq(1)
       .find("[data-cy=donation-impact-list-item-output]")
       .first()
-      .should("contain.text", "20,2");
+      .should("contain.text", "20,0");
 
     cy.get("[data-cy=generic-list-table]")
       .first()

--- a/cypress/fixtures/no/grants.json
+++ b/cypress/fixtures/no/grants.json
@@ -54,8 +54,8 @@
         }
       ],
       "language": "no",
-      "start_year": 2021,
-      "start_month": 4
+      "start_year": 2019,
+      "start_month": 0
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6882,6 +6882,17 @@
         "node": ">=20.19.0"
       }
     },
+    "node_modules/@sanity/cli-core/node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@sanity/cli-core/node_modules/configstore": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-7.1.0.tgz",
@@ -7279,6 +7290,23 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@sanity/cli-core/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@sanity/cli/node_modules/find-up": {
@@ -8047,6 +8075,17 @@
         "node": ">=20.19"
       }
     },
+    "node_modules/@sanity/runtime-cli/node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@sanity/runtime-cli/node_modules/eventsource": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.1.0.tgz",
@@ -8235,6 +8274,23 @@
       },
       "peerDependencies": {
         "vite": "*"
+      }
+    },
+    "node_modules/@sanity/runtime-cli/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@sanity/schema": {
@@ -26036,6 +26092,17 @@
         "node": ">=20.19 <22 || >=22.12"
       }
     },
+    "node_modules/sanity/node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/sanity/node_modules/@types/use-sync-external-store": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
@@ -26374,6 +26441,23 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/sanity/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/sass": {
@@ -28462,6 +28546,14 @@
         "node": ">=18.17"
       }
     },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
@@ -28896,6 +28988,17 @@
         "url": "https://opencollective.com/antfu"
       }
     },
+    "node_modules/vite-node/node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/vite-node/node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -29029,6 +29132,23 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-node/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/void-elements": {


### PR DESCRIPTION
## Summary

Smart distribution donations (money routed via a GiveWell grant) were being converted to outputs using the **generic cost-effectiveness evaluation** (`converted_cost_per_output` from `/api/evaluations`) instead of the **actual grant's own cost-per-output**. The grant already specifies exactly what it purchased (`allotment.converted_cost_per_output` / `number_outputs_purchased`), so re-deriving outputs from a separate evaluation is both conceptually wrong and, in practice, produces materially different numbers.

Two compounding issues were observed by probing `impact.gieffektivt.no` directly:

1. **Wrong source of truth** — grant money used the evaluation's average cost estimate rather than the grant's own cost.
2. **Stale evaluations** — for 2024–2025 grants, the "most relevant" evaluation returned is stuck at 2023-01 for every charity, so an outdated estimate was applied on top of issue #1.

Comparing the grant's own cost-per-output vs. the evaluation the site was using:

| Grant | Charity | Grant cost/output | Eval cost/output (used) | Output error |
|---|---|---|---|---|
| 2025-01 | NI | 1019.0 | 1507.0 | +47.9% |
| 2024-04 | MC | 272.1 | 87.1 | −68.0% |
| 2024-04 | HKI | 30.0 | 22.1 | −26.3% |
| 2024-03 | MC | 148.1 | 84.8 | −42.7% |
| 2024-02 | AMF | 44.3 | 61.5 | +38.8% |

## Changes

- `DonationsAggregateImpactTable/_util.ts`: capture `smart_distribution_outputs` during aggregation using the grant allotment's `converted_cost_per_output`; `aggregateImpact` now uses those grant-derived outputs for the smart-distribution portion and reserves the evaluation estimate for direct/custom donations only.
- `DonationImpact/GlobalHealth/DonationImpactGlobalHealth.tsx`: compute per-allotment grant outputs when spreading the grant and pass them through.
- `DonationImpact/GlobalHealth/DonationImpactItemGlobalHealth.tsx`: blend grant-derived outputs (smart distribution) with evaluation-based outputs (direct portion).

Direct/custom donations to a specific org are unchanged and still use the most relevant evaluation.

## Test plan

- [ ] Verify aggregated impact table totals for a profile with GiveWell-fund (smart distribution) donations reflect grant cost-per-output.
- [ ] Verify per-donation global health impact rows for grant-routed money match grant outputs.
- [ ] Verify direct/custom donations to a specific org are unchanged.
- [ ] Confirm constituent (kr) breakdowns (via fond / direkte fordelt) still render correctly.

Made with [Cursor](https://cursor.com)