### PR TITLE
Fix cause area percentage shares drifting from exactly 100

### DIFF
--- a/components/shared/components/Widget/store/donation/saga.ts
+++ b/components/shared/components/Widget/store/donation/saga.ts
@@ -20,6 +20,7 @@ import { CauseArea } from "../../types/CauseArea";
 import {
   calculateDonationBreakdown,
   calculateOrganizationSharesWithinCauseArea,
+  distributeSharesWithRemainder,
 } from "../../utils/donationCalculations";
 
 export function* draftVippsAgreement(): SagaIterator<void> {
@@ -232,11 +233,10 @@ export function* registerDonation(
       smartDistributionTotal,
     );
 
-    let distributionPayload: {
+    let causeAreaEntries: {
       id: number;
       standardSplit: boolean;
       name: string;
-      percentageShare: string;
       amount: number;
       organizations: { id: number; percentageShare: string; amount: number }[];
     }[] = [];
@@ -250,9 +250,6 @@ export function* registerDonation(
       // Only add areas that have organizations with amounts
       if (orgAmountsForArea.length > 0 && breakdown.totalAmount > 0) {
         const areaAmount = orgAmountsForArea.reduce((sum, org) => sum + org.amount, 0);
-        // Cause area's percentage is of the overall donation, but each
-        // organization's percentage share must be of this cause area
-        const areaPercentage = (areaAmount / breakdown.totalAmount) * 100;
         const areaOrgPayloads = calculateOrganizationSharesWithinCauseArea(orgAmountsForArea);
 
         // Determine the standardSplit flag
@@ -267,12 +264,11 @@ export function* registerDonation(
           isStandardSplit = true;
         }
 
-        distributionPayload.push({
+        causeAreaEntries.push({
           id: area.id,
           name: area.name,
           standardSplit: isStandardSplit,
-          percentageShare: areaPercentage.toFixed(8),
-          amount: Math.round(areaAmount),
+          amount: areaAmount,
           organizations: areaOrgPayloads,
         });
       }
@@ -281,12 +277,7 @@ export function* registerDonation(
     // Add operations cause area if there's an operations amount
     if (breakdown.operationsAmount > 0) {
       const operationsCauseArea = allCauseAreas.find((ca) => ca.id === OPERATIONS_CAUSE_AREA_ID);
-      if (
-        operationsCauseArea &&
-        !distributionPayload.some((p) => p.id === OPERATIONS_CAUSE_AREA_ID)
-      ) {
-        const operationsPercentage = (breakdown.operationsAmount / breakdown.totalAmount) * 100;
-
+      if (operationsCauseArea && !causeAreaEntries.some((p) => p.id === OPERATIONS_CAUSE_AREA_ID)) {
         // Calculate organization amounts for the operations cause area, then
         // scale them to percentages of this cause area (not of the total)
         const operationsOrgAmounts = operationsCauseArea.organizations
@@ -298,16 +289,27 @@ export function* registerDonation(
         const operationsOrgPayloads =
           calculateOrganizationSharesWithinCauseArea(operationsOrgAmounts);
 
-        distributionPayload.push({
+        causeAreaEntries.push({
           id: operationsCauseArea.id,
           name: operationsCauseArea.name,
           standardSplit: true,
-          percentageShare: operationsPercentage.toFixed(8),
-          amount: Math.round(breakdown.operationsAmount),
+          amount: breakdown.operationsAmount,
           organizations: operationsOrgPayloads,
         });
       }
     }
+
+    // Cause area shares must sum to exactly 100 (the backend enforces this with
+    // zero tolerance), so - like organization shares within a cause area - the
+    // largest cause area absorbs the rounding remainder instead of each area's
+    // share being rounded independently, which can drift by a fraction of a
+    // percent (e.g. 100.00000001) once there are 2+ areas in the split.
+    const distributionPayload = distributeSharesWithRemainder(causeAreaEntries).map(
+      ({ amount, ...rest }) => ({
+        ...rest,
+        amount: Math.round(amount),
+      }),
+    );
 
     // --- Prepare final data object for API ---
     const data: RegisterDonationObject & {

--- a/components/shared/components/Widget/utils/donationCalculations.test.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.test.ts
@@ -1,4 +1,65 @@
-import { calculateOrganizationSharesWithinCauseArea } from "./donationCalculations";
+import {
+  calculateOrganizationSharesWithinCauseArea,
+  distributeSharesWithRemainder,
+} from "./donationCalculations";
+
+describe("distributeSharesWithRemainder", () => {
+  const sumOfShares = (shares: { percentageShare: string }[]) =>
+    shares.reduce((sum, share) => sum + parseFloat(share.percentageShare), 0);
+
+  // Rounding each share independently to 8 decimals (as the widget used to do
+  // for cause areas, before they went through this same remainder-absorbing
+  // helper organization shares already used) can drift below or above 100 -
+  // which is exactly what caused a production incident: the backend rejected
+  // a donation with "Cause area share must sum to 100, but was 100.00000001".
+  const naiveIndependentRounding = (amounts: { amount: number }[]) => {
+    const total = amounts.reduce((sum, item) => sum + item.amount, 0);
+    return amounts.map((item) => ((item.amount / total) * 100).toFixed(8));
+  };
+
+  it("sums to exactly 100 for splits where naive independent rounding drifts below 100", () => {
+    const causeAreas = [
+      { id: 1, amount: 1 },
+      { id: 2, amount: 1 },
+      { id: 3, amount: 1 },
+    ];
+
+    const naiveSum = naiveIndependentRounding(causeAreas).reduce(
+      (sum, share) => sum + parseFloat(share),
+      0,
+    );
+    expect(naiveSum).not.toBe(100); // demonstrates the bug this replaces
+
+    expect(sumOfShares(distributeSharesWithRemainder(causeAreas))).toBe(100);
+  });
+
+  it("sums to exactly 100 for splits where naive independent rounding drifts above 100", () => {
+    const causeAreas = Array.from({ length: 6 }, (_, i) => ({ id: i, amount: 1 }));
+
+    const naiveSum = naiveIndependentRounding(causeAreas).reduce(
+      (sum, share) => sum + parseFloat(share),
+      0,
+    );
+    expect(naiveSum).not.toBe(100); // demonstrates the bug this replaces
+
+    expect(sumOfShares(distributeSharesWithRemainder(causeAreas))).toBe(100);
+  });
+
+  it("preserves fields other than amount on each item", () => {
+    const shares = distributeSharesWithRemainder([
+      { id: 1, amount: 40, name: "Area A" },
+      { id: 2, amount: 60, name: "Area B" },
+    ]);
+
+    expect(shares.find((s) => s.id === 1)?.name).toBe("Area A");
+    expect(shares.find((s) => s.id === 2)?.name).toBe("Area B");
+  });
+
+  it("returns an empty array when the total is zero or negative", () => {
+    expect(distributeSharesWithRemainder([])).toEqual([]);
+    expect(distributeSharesWithRemainder([{ id: 1, amount: 0 }])).toEqual([]);
+  });
+});
 
 describe("calculateOrganizationSharesWithinCauseArea", () => {
   const sumOfShares = (shares: { percentageShare: string }[]) =>

--- a/components/shared/components/Widget/utils/donationCalculations.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.ts
@@ -219,31 +219,29 @@ export interface OrganizationSharePayload {
 }
 
 /**
- * Converts organization amounts within a single cause area into percentage
- * shares of that cause area (not of the overall donation). The organization
- * with the largest amount is placed last and absorbs the rounding remainder,
- * so the returned shares are guaranteed to sum to exactly 100 - even once
- * re-parsed as floats - which the backend requires within a cause area.
+ * Converts a list of amounts into percentage shares of their total. Each
+ * share is independently rounded to 8 decimals except the item with the
+ * largest amount, which absorbs the rounding remainder - so the shares are
+ * guaranteed to sum to exactly 100, even once re-parsed as floats, which the
+ * backend requires for both cause area and organization-level splits.
  */
-export function calculateOrganizationSharesWithinCauseArea(
-  organizationAmounts: { id: number; amount: number }[],
-): OrganizationSharePayload[] {
-  const areaTotal = organizationAmounts.reduce((sum, org) => sum + org.amount, 0);
+export function distributeSharesWithRemainder<T extends { id: number; amount: number }>(
+  amounts: T[],
+): (T & { percentageShare: string })[] {
+  const total = amounts.reduce((sum, item) => sum + item.amount, 0);
 
-  if (areaTotal <= 0) return [];
+  if (total <= 0) return [];
 
-  const largestIndex = organizationAmounts.reduce(
-    (maxIndex, org, index) =>
-      org.amount > organizationAmounts[maxIndex].amount ? index : maxIndex,
+  const largestIndex = amounts.reduce(
+    (maxIndex, item, index) => (item.amount > amounts[maxIndex].amount ? index : maxIndex),
     0,
   );
-  const largest = organizationAmounts[largestIndex];
-  const others = organizationAmounts.filter((_, index) => index !== largestIndex);
+  const largest = amounts[largestIndex];
+  const others = amounts.filter((_, index) => index !== largestIndex);
 
-  const otherShares = others.map((org) => ({
-    id: org.id,
-    percentageShare: ((org.amount / areaTotal) * 100).toFixed(8),
-    amount: Math.round(org.amount),
+  const otherShares = others.map((item) => ({
+    ...item,
+    percentageShare: ((item.amount / total) * 100).toFixed(8),
   }));
 
   const sumOfOthers = otherShares.reduce(
@@ -251,12 +249,19 @@ export function calculateOrganizationSharesWithinCauseArea(
     0,
   );
 
-  return [
-    ...otherShares,
-    {
-      id: largest.id,
-      percentageShare: (100 - sumOfOthers).toString(),
-      amount: Math.round(largest.amount),
-    },
-  ];
+  return [...otherShares, { ...largest, percentageShare: (100 - sumOfOthers).toString() }];
+}
+
+/**
+ * Converts organization amounts within a single cause area into percentage
+ * shares of that cause area (not of the overall donation).
+ */
+export function calculateOrganizationSharesWithinCauseArea(
+  organizationAmounts: { id: number; amount: number }[],
+): OrganizationSharePayload[] {
+  return distributeSharesWithRemainder(organizationAmounts).map((share) => ({
+    id: share.id,
+    percentageShare: share.percentageShare,
+    amount: Math.round(share.amount),
+  }));
 }

--- a/cypress/e2e/dk/widget-multiple-cause-areas.js
+++ b/cypress/e2e/dk/widget-multiple-cause-areas.js
@@ -106,7 +106,7 @@ describe("Widget multiple cause areas", () => {
       expect(req.body.amount).to.eq(1000);
       expect(req.body.distributionCauseAreas).to.have.length(1);
       expect(req.body.distributionCauseAreas[0].id).to.eq(4);
-      expect(req.body.distributionCauseAreas[0].percentageShare).to.eq("100.00000000");
+      expect(parseFloat(req.body.distributionCauseAreas[0].percentageShare)).to.eq(100);
 
       req.reply({
         statusCode: 200,

--- a/cypress/e2e/no/widget-multiple-cause-areas.js
+++ b/cypress/e2e/no/widget-multiple-cause-areas.js
@@ -144,7 +144,7 @@ describe("Widget multiple cause areas", () => {
       expect(req.body.amount).to.eq(1000);
       expect(req.body.distributionCauseAreas).to.have.length(1);
       expect(req.body.distributionCauseAreas[0].id).to.eq(4);
-      expect(req.body.distributionCauseAreas[0].percentageShare).to.eq("100.00000000");
+      expect(parseFloat(req.body.distributionCauseAreas[0].percentageShare)).to.eq(100);
 
       req.reply({
         statusCode: 200,

--- a/cypress/e2e/no/widget.js
+++ b/cypress/e2e/no/widget.js
@@ -122,7 +122,12 @@ describe("Widget", () => {
     cy.nextWidgetPane();
     cy.wait(500);
 
-    cy.get("[data-cy=avtalegiro-form]").submit();
+    // The form's own native submit goes straight to the external
+    // avtalegiro.no page (its action is that URL), bypassing the button's
+    // onClick handler that actually dispatches the draftAvtaleGiro saga and
+    // calls /avtalegiro/draft - so the button itself must be clicked, not
+    // the form submitted directly, to exercise that request.
+    cy.get("[data-cy=avtalegiro-form] button").click({ force: true });
 
     cy.wait("@draftAvtaleGiro");
   });

--- a/cypress/e2e/no/widget.js
+++ b/cypress/e2e/no/widget.js
@@ -126,10 +126,18 @@ describe("Widget", () => {
     // avtalegiro.no page (its action is that URL), bypassing the button's
     // onClick handler that actually dispatches the draftAvtaleGiro saga and
     // calls /avtalegiro/draft - so the button itself must be clicked, not
-    // the form submitted directly, to exercise that request.
+    // the form submitted directly, to exercise that request. But the saga
+    // itself calls the form's native submit() on success, which would send
+    // the browser to that real external page - stub it out so the test only
+    // verifies the request, without actually navigating away.
+    cy.window().then((win) => {
+      cy.stub(win.HTMLFormElement.prototype, "submit").as("formSubmit");
+    });
+
     cy.get("[data-cy=avtalegiro-form] button").click({ force: true });
 
     cy.wait("@draftAvtaleGiro");
+    cy.get("@formSubmit").should("have.been.calledOnce");
   });
 
   it("End-2-End single vipps donation", () => {

--- a/cypress/e2e/se/widget-registration-multiple-areas.js
+++ b/cypress/e2e/se/widget-registration-multiple-areas.js
@@ -62,6 +62,41 @@ describe("Swedish Widget - Multiple Cause Areas Registration", () => {
     });
   });
 
+  it("Should keep cause area shares summing to exactly 100 even for splits with repeating decimals", () => {
+    // Equal cause area amounts split into percentages that don't terminate
+    // cleanly in decimal (33.333...%). Rounding each cause area's share
+    // independently (rather than having one area absorb the remainder, as
+    // organization-within-cause-area shares already do) can drift away from
+    // exactly 100 - e.g. 99.99999999 - which the backend's distribution
+    // check rejects with zero tolerance. This previously caused
+    // "/donations/register" to fail in production with an error like
+    // "Cause area share must sum to 100, but was 100.00000001".
+    cy.get("[data-cy=cause-area-multiple]").click();
+
+    setCauseAreaAmount(1, 100, false);
+    setCauseAreaAmount(2, 100, false);
+    setCauseAreaAmount(3, 100, false);
+
+    cy.get("[data-cy=next-button]").click();
+    cy.get("[data-cy=name-input]").type("Test Donor");
+    cy.get("[data-cy=email-input]").type("test@example.com");
+
+    cy.get("[data-cy^=payment-method-]").first().click();
+
+    cy.wait("@registerDonation").then((interception) => {
+      const { body } = interception.request;
+
+      expect(body.amount).to.equal(300);
+      expect(body.distributionCauseAreas).to.have.length(3);
+
+      const sumOfShares = body.distributionCauseAreas.reduce(
+        (sum, ca) => sum + parseFloat(ca.percentageShare),
+        0,
+      );
+      expect(sumOfShares).to.equal(100);
+    });
+  });
+
   it("Should handle custom organization distribution correctly", () => {
     cy.get("[data-cy=cause-area-multiple]").click();
     setCauseAreaAmount(1, 1000, false); // operations cut can default to on


### PR DESCRIPTION
## Summary

- Each cause area's `percentageShare` was rounded to 8 decimals independently in `registerDonation()` (saga.ts), so a donation split across 2+ cause areas (multiple cause areas, or a single cause area + a percentage-based operations cut) could sum to e.g. `100.00000001` instead of exactly `100`.
- The backend's distribution check (`effekt-backend`'s `getKIDbySplit`) sums shares with `decimal.js` and rejects anything that isn't exactly `"100"`, so this failed `/donations/register` in production for affected donors (seen live on the Swedish backend: `Cause area share must sum to 100, but was 100.00000001`).
- Fix: extracted the remainder-absorption logic that `calculateOrganizationSharesWithinCauseArea` already used (largest item absorbs the rounding remainder, guaranteeing an exact sum of 100) into a reusable `distributeSharesWithRemainder` helper, and applied it one level up to the cause-area split itself, which previously had no such guarantee.

## Test plan

- [x] `donationCalculations.test.ts`: added tests proving naive independent rounding drifts (both below and above 100) for equal-share splits, and that `distributeSharesWithRemainder` corrects it to exactly 100.
- [x] Existing `calculateOrganizationSharesWithinCauseArea` unit tests still pass unchanged.
- [x] Added a new Cypress e2e test (`cypress/e2e/se/widget-registration-multiple-areas.js`) covering a 3-way equal cause-area split (100/100/100), asserting the actual `/donations/register` request body sums to exactly 100 — this reproduces the production incident's root cause on the frontend side.
- [ ] Not run against a live dev server locally (SE site variant needs infra I didn't have readily available in this session) - relying on unit test coverage + `tsc`/`eslint` passing clean. Please have CI's `e2e-se` job confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)