### PR TITLE
Hide smart-distribution sum when custom is picked for single cause area

### DIFF
--- a/components/shared/components/Widget/components/panes/SingleCauseAreaPane/index.tsx
+++ b/components/shared/components/Widget/components/panes/SingleCauseAreaPane/index.tsx
@@ -152,6 +152,13 @@ export const SingleCauseAreaPane: React.FC<SingleCauseAreaPaneProps> = ({
     .sort((a, b) => a.ordering - b.ordering);
   const hasMultipleOrgs = activeOrganizations.length > 1;
   const distributionType = causeAreaDistributionType[causeArea.id] ?? ShareType.STANDARD;
+  // Once the donor enters per-organization amounts themselves those are the total (see
+  // effectiveTotalAmount), so the cause area sum above would be a stale, silently ignored
+  // field - hide it, matching CauseAreaForm in the multiple-cause-area widget. Prefilled
+  // distributions are excluded: they're switched to custom for the donor (not by them), and
+  // there the sum is still the primary input that the prefilled shares track a split of.
+  const hideAmountInput =
+    hasMultipleOrgs && distributionType === ShareType.CUSTOM && !hasPrefilledOrgs;
 
   const suggestedSums = recurring
     ? amountContext.preset_amounts_recurring
@@ -250,11 +257,7 @@ export const SingleCauseAreaPane: React.FC<SingleCauseAreaPaneProps> = ({
             onSelect={(value) => dispatch(setRecurring(value as RecurringDonation))}
           />
 
-          <AnimateHeight
-            height={hasMultipleOrgs && distributionType === ShareType.CUSTOM ? 0 : "auto"}
-            animateOpacity
-            duration={300}
-          >
+          <AnimateHeight height={hideAmountInput ? 0 : "auto"} animateOpacity duration={300}>
             {amountInput}
           </AnimateHeight>
 

--- a/components/shared/components/Widget/components/panes/SingleCauseAreaPane/index.tsx
+++ b/components/shared/components/Widget/components/panes/SingleCauseAreaPane/index.tsx
@@ -4,6 +4,7 @@ import { NumericFormat } from "react-number-format";
 import { usePlausible } from "next-plausible";
 import { PortableText } from "@portabletext/react";
 import { Dispatch } from "@reduxjs/toolkit";
+import AnimateHeight from "react-animate-height";
 
 import { Pane, PaneContainer, PaneTitle } from "../Panes.style";
 import {
@@ -249,7 +250,13 @@ export const SingleCauseAreaPane: React.FC<SingleCauseAreaPaneProps> = ({
             onSelect={(value) => dispatch(setRecurring(value as RecurringDonation))}
           />
 
-          {amountInput}
+          <AnimateHeight
+            height={hasMultipleOrgs && distributionType === ShareType.CUSTOM ? 0 : "auto"}
+            animateOpacity
+            duration={300}
+          >
+            {amountInput}
+          </AnimateHeight>
 
           {hasMultipleOrgs && (
             <ShareSelectionSpacer>

--- a/cypress/e2e/no/widget.js
+++ b/cypress/e2e/no/widget.js
@@ -199,6 +199,8 @@ describe("Widget", () => {
     cy.pickSingleDonation();
     cy.get("[data-cy^=donation-sum-input]").type("100");
     cy.get("[data-cy=radio-custom-share]").first().click({ force: true });
+    // The smart-distribution overall sum is hidden once custom takes over.
+    cy.get("[data-cy^=donation-sum-input]").should("not.be.visible");
     cy.get("[data-cy=org-12]").clear();
     cy.get("[data-cy=org-12]").type(500);
     cy.get("[data-cy=org-12]").type("{moveToStart}");


### PR DESCRIPTION
## Summary
- Ports the existing multi-cause-area behavior (`CauseAreaForm.tsx`) to the single-cause-area widget (`SingleCauseAreaPane`, used for platforms like Norway with only one active cause area): once the donor switches to custom per-organization amounts, the overall smart-distribution sum field collapses out of view instead of staying visible/editable.
- The submitted total already correctly used the custom org amounts (via `useAmountCalculation`), so this is a display-only fix — it just brings the UI in line with the calculation, matching donor expectations from the multi-cause-area flow.

## Test plan
- [x] `npx tsc --noEmit` clean for the changed files
- [x] Added a Cypress assertion in `cypress/e2e/no/widget.js` ("End-2-End shared donation") confirming the sum input becomes hidden after selecting custom distribution
- [x] Ran the full NO widget Cypress suite headless (`cypress:no:headless`) against a local dev server — all 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)