### PR TITLE
Improve Min Side after moving to amount-based donation widget

### DIFF
--- a/components/profile/shared/DistributionCauseAreaInput/Distribution.module.scss
+++ b/components/profile/shared/DistributionCauseAreaInput/Distribution.module.scss
@@ -59,37 +59,10 @@
   }
 }
 
-.warning-box {
-  padding: 0.5em 1.2em;
-  font-size: 0.8em;
-  margin-top: 1.5em;
-  color: var(--secondary);
-  background: var(--primary);
-  border-radius: 0.5em;
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-
-  span {
-    border-left: 1px solid var(--secondary);
-    display: flex;
-    padding-left: 1em;
-    height: 100%;
-    align-items: center;
-    margin-left: 1em;
-    font-weight: 600;
-  }
-}
-
 @container (max-width: 45em) {
   .grid {
     grid-template-columns: 1fr;
     grid-auto-flow: row;
-  }
-
-  .warning-box {
-    width: 100%;
-    justify-content: space-between;
   }
 
   .share-wrapper {

--- a/components/profile/shared/DistributionCauseAreaInput/Distribution.tsx
+++ b/components/profile/shared/DistributionCauseAreaInput/Distribution.tsx
@@ -3,20 +3,16 @@ import { DistributionCauseArea } from "../../../../models";
 import style from "./Distribution.module.scss";
 import { useCauseAreas } from "../../../../_queries";
 import { useAuth0 } from "@auth0/auth0-react";
-import AnimateHeight from "react-animate-height";
+import { isAllocationVisible } from "../distributionAmounts";
 
 export const DistributionController: React.FC<{
   causeArea: DistributionCauseArea;
+  savedCauseArea?: DistributionCauseArea;
   onChange: (causeArea: DistributionCauseArea) => void;
-}> = ({ causeArea, onChange }) => {
+}> = ({ causeArea, savedCauseArea = causeArea, onChange }) => {
   const { getAccessTokenSilently } = useAuth0();
 
   const { data: causeAreas, loading: causeArasLoading } = useCauseAreas(getAccessTokenSilently);
-
-  const sum = causeArea.organizations?.reduce(
-    (acc, curr) => acc + parseFloat(curr.percentageShare),
-    0,
-  );
 
   if (causeArasLoading) return <div>Loading cause areas...</div>;
 
@@ -31,10 +27,12 @@ export const DistributionController: React.FC<{
     <div className={style.wrapper}>
       <div className={style.grid}>
         {currentCauseAreaOrgs
-          .filter(
-            (org) =>
-              org.isActive ||
-              parseFloat(causeArea.organizations.find((o) => org.id)?.percentageShare ?? "0") === 0,
+          .filter((org) =>
+            isAllocationVisible(
+              org.isActive,
+              savedCauseArea.organizations.find((organization) => organization.id === org.id)
+                ?.amount,
+            ),
           )
           .map((org) => (
             <div key={org.id} className={style["share-wrapper"]}>
@@ -42,44 +40,43 @@ export const DistributionController: React.FC<{
               <div>
                 <input
                   type="text"
-                  defaultValue={
-                    Math.round(
-                      parseFloat(
-                        causeArea.organizations?.find((o) => o.id === org.id)?.percentageShare ||
-                          "0",
-                      ),
-                    ).toString() || 0
+                  value={
+                    causeArea.organizations?.find((organization) => organization.id === org.id)
+                      ?.amount ?? 0
                   }
                   onChange={(e) => {
-                    const percentageShare = parseFloat(e.target.value) || 0;
+                    const amount = Math.max(0, parseInt(e.target.value, 10) || 0);
                     const organizations = [...causeArea.organizations];
                     const index = organizations.findIndex((o) => o.id === org.id);
                     if (index === -1) {
                       organizations.push({
                         id: org.id,
                         name: org.name,
-                        percentageShare: percentageShare.toFixed(0),
+                        percentageShare: "0",
+                        amount,
                       });
                     } else {
                       organizations[index] = {
                         ...organizations[index],
-                        percentageShare: percentageShare.toFixed(0),
+                        amount,
                       };
                     }
-                    onChange({ ...causeArea, organizations });
+                    onChange({
+                      ...causeArea,
+                      amount: organizations.reduce(
+                        (total, organization) => total + (organization.amount ?? 0),
+                        0,
+                      ),
+                      organizations,
+                    });
                   }}
                   data-cy="distribution-input"
                 />
-                <span>%</span>
+                <span>kr</span>
               </div>
             </div>
           ))}
       </div>
-      <AnimateHeight height={sum !== 100 ? "auto" : 0} animateOpacity={true}>
-        <div className={style["warning-box"]} data-cy="distribution-warning">
-          Fordeling må summere til 100 <span>{sum} / 100</span>
-        </div>
-      </AnimateHeight>
     </div>
   );
 };

--- a/components/profile/shared/distributionAmounts.test.ts
+++ b/components/profile/shared/distributionAmounts.test.ts
@@ -54,9 +54,10 @@ it("orders distributions using the cause area configuration", () => {
   expect(ordered.map((causeArea) => causeArea.id)).toEqual([3, 1, 2]);
 });
 
-it("only shows inactive allocations while the saved agreement uses them", () => {
+it("only shows inactive allocations when saved or included in the recommended distribution", () => {
   expect(isAllocationVisible(false, 100)).toBe(true);
   expect(isAllocationVisible(false, 0)).toBe(false);
+  expect(isAllocationVisible(false, 0, 100)).toBe(true);
   expect(isAllocationVisible(true, 0)).toBe(true);
 });
 

--- a/components/profile/shared/distributionAmounts.test.ts
+++ b/components/profile/shared/distributionAmounts.test.ts
@@ -1,0 +1,149 @@
+import { expect, it } from "@jest/globals";
+import { Distribution } from "../../../models";
+import {
+  hydrateDistributionAmounts,
+  isAllocationVisible,
+  orderDistributionCauseAreas,
+  prepareDistributionForSave,
+  setCauseAreaStandardSplit,
+  setStandardCauseAreaAmount,
+} from "./distributionAmounts";
+
+const distribution: Distribution = {
+  kid: "kid",
+  donorId: 1,
+  taxUnitId: null,
+  causeAreas: [
+    {
+      id: 1,
+      standardSplit: false,
+      percentageShare: "33.33333333",
+      organizations: [
+        { id: 1, percentageShare: "33.33333333" },
+        { id: 2, percentageShare: "66.66666667" },
+      ],
+    },
+    {
+      id: 2,
+      standardSplit: false,
+      percentageShare: "33.33333333",
+      organizations: [{ id: 3, percentageShare: "100" }],
+    },
+    {
+      id: 3,
+      standardSplit: true,
+      percentageShare: "33.33333334",
+      organizations: [{ id: 4, percentageShare: "100" }],
+    },
+  ],
+};
+
+const sumPercentages = (items: { percentageShare: string }[]) =>
+  items.reduce((sum, item) => sum + parseFloat(item.percentageShare), 0);
+
+it("orders distributions using the cause area configuration", () => {
+  const ordered = orderDistributionCauseAreas(
+    [distribution.causeAreas[2], distribution.causeAreas[0], distribution.causeAreas[1]],
+    [
+      { id: 1, ordering: 2 },
+      { id: 2, ordering: 3 },
+      { id: 3, ordering: 1 },
+    ],
+  );
+
+  expect(ordered.map((causeArea) => causeArea.id)).toEqual([3, 1, 2]);
+});
+
+it("only shows inactive allocations while the saved agreement uses them", () => {
+  expect(isAllocationVisible(false, 100)).toBe(true);
+  expect(isAllocationVisible(false, 0)).toBe(false);
+  expect(isAllocationVisible(true, 0)).toBe(true);
+});
+
+it("keeps the standard organization synchronized with its cause area amount", () => {
+  const causeArea = hydrateDistributionAmounts(distribution, 1000).causeAreas[2];
+  const updated = setStandardCauseAreaAmount(causeArea, 500, 4);
+
+  expect(updated.amount).toBe(500);
+  expect(updated.organizations.find((organization) => organization.id === 4)?.amount).toBe(500);
+});
+
+it("preserves organization amounts while smart distribution is toggled", () => {
+  const causeArea = {
+    ...distribution.causeAreas[0],
+    amount: 300,
+    organizations: [
+      { id: 1, percentageShare: "33.33333333", amount: 100 },
+      { id: 2, percentageShare: "66.66666667", amount: 200 },
+    ],
+  };
+
+  const enabled = setCauseAreaStandardSplit(causeArea, true);
+  const disabled = setCauseAreaStandardSplit(enabled, false);
+
+  expect(enabled.organizations).toEqual(causeArea.organizations);
+  expect(disabled.organizations).toEqual(causeArea.organizations);
+});
+
+it("moves a smart distribution total to its standard organization only in the payload", () => {
+  const causeArea = setCauseAreaStandardSplit(
+    {
+      ...distribution.causeAreas[0],
+      amount: 300,
+      organizations: [
+        { id: 1, percentageShare: "33.33333333", amount: 100 },
+        { id: 2, percentageShare: "66.66666667", amount: 200 },
+      ],
+    },
+    true,
+  );
+
+  const payload = prepareDistributionForSave(
+    { ...distribution, causeAreas: [causeArea] },
+    300,
+    new Map([[1, 1]]),
+  );
+
+  expect(payload.causeAreas[0].organizations).toEqual([
+    { id: 1, percentageShare: "100", amount: 300 },
+  ]);
+});
+
+it("hydrates legacy percentage distributions with exact whole amounts", () => {
+  const hydrated = hydrateDistributionAmounts(distribution, 1000);
+
+  expect(hydrated.causeAreas.map((causeArea) => causeArea.amount)).toEqual([333, 333, 334]);
+  expect(
+    hydrated.causeAreas[0].organizations.reduce(
+      (sum, organization) => sum + (organization.amount ?? 0),
+      0,
+    ),
+  ).toBe(333);
+});
+
+it("builds amount and percentage payloads whose totals are exact", () => {
+  const payload = prepareDistributionForSave(hydrateDistributionAmounts(distribution, 1000), 1000);
+
+  expect(payload.causeAreas.reduce((sum, causeArea) => sum + (causeArea.amount ?? 0), 0)).toBe(
+    1000,
+  );
+  expect(sumPercentages(payload.causeAreas)).toBe(100);
+
+  payload.causeAreas.forEach((causeArea) => {
+    expect(
+      causeArea.organizations.reduce((sum, organization) => sum + (organization.amount ?? 0), 0),
+    ).toBe(causeArea.amount);
+    expect(sumPercentages(causeArea.organizations)).toBe(100);
+  });
+});
+
+it("removes zero allocations from the payload", () => {
+  const hydrated = hydrateDistributionAmounts(distribution, 1000);
+  hydrated.causeAreas[0].organizations[0].amount = 0;
+  hydrated.causeAreas[0].organizations[1].amount = 333;
+
+  const payload = prepareDistributionForSave(hydrated, 1000);
+
+  expect(payload.causeAreas[0].organizations).toHaveLength(1);
+  expect(payload.causeAreas[0].organizations[0].amount).toBe(333);
+});

--- a/components/profile/shared/distributionAmounts.ts
+++ b/components/profile/shared/distributionAmounts.ts
@@ -1,0 +1,207 @@
+import { Distribution, DistributionCauseArea } from "../../../models";
+import { distributeSharesWithRemainder } from "../../shared/components/Widget/utils/donationCalculations";
+import { CauseArea } from "../../shared/components/Widget/types/CauseArea";
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+const isAmount = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0;
+
+export const isAllocationVisible = (isActive: boolean | undefined, savedAmount?: number) =>
+  isActive !== false || (savedAmount ?? 0) > 0;
+
+export const orderDistributionCauseAreas = (
+  causeAreas: DistributionCauseArea[],
+  systemCauseAreas: Pick<CauseArea, "id" | "ordering">[],
+) => {
+  const ordering = new Map(systemCauseAreas.map((causeArea) => [causeArea.id, causeArea.ordering]));
+  return [...causeAreas].sort(
+    (a, b) =>
+      (ordering.get(a.id) ?? Number.MAX_SAFE_INTEGER) -
+      (ordering.get(b.id) ?? Number.MAX_SAFE_INTEGER),
+  );
+};
+
+export const getStandardOrganizationId = (causeArea: CauseArea) =>
+  causeArea.organizations.find((organization) => (organization.standardShare ?? 0) > 0)?.id ??
+  causeArea.organizations[0]?.id;
+
+export const getStandardOrganizationIds = (causeAreas: CauseArea[]) =>
+  new Map(
+    causeAreas.flatMap((causeArea) => {
+      const organizationId = getStandardOrganizationId(causeArea);
+      return organizationId === undefined ? [] : [[causeArea.id, organizationId] as const];
+    }),
+  );
+
+export const setStandardCauseAreaAmount = (
+  causeArea: DistributionCauseArea,
+  amount: number,
+  standardOrganizationId: number,
+): DistributionCauseArea => {
+  const organizations = causeArea.organizations.some(
+    (organization) => organization.id === standardOrganizationId,
+  )
+    ? causeArea.organizations
+    : [
+        ...causeArea.organizations,
+        { id: standardOrganizationId, percentageShare: "100", amount: 0 },
+      ];
+
+  return {
+    ...causeArea,
+    amount,
+    organizations: organizations.map((organization) =>
+      organization.id === standardOrganizationId ? { ...organization, amount } : organization,
+    ),
+  };
+};
+
+export const setCauseAreaStandardSplit = (
+  causeArea: DistributionCauseArea,
+  standardSplit: boolean,
+): DistributionCauseArea => ({
+  ...causeArea,
+  standardSplit,
+  amount: causeArea.organizations.reduce(
+    (total, organization) => total + (organization.amount ?? 0),
+    0,
+  ),
+});
+
+const allocateTotal = <T extends { percentageShare: string }>(total: number, items: T[]) => {
+  if (items.length === 0) return [];
+
+  const roundedTotal = Math.max(0, Math.round(total));
+  const weights = items.map((item) => Math.max(0, parseFloat(item.percentageShare) || 0));
+  const weightTotal = weights.reduce((sum, weight) => sum + weight, 0);
+  const effectiveWeights =
+    weightTotal > 0 ? weights : items.map((_, index) => (index === 0 ? 1 : 0));
+  const effectiveTotal = effectiveWeights.reduce((sum, weight) => sum + weight, 0);
+  const exactAmounts = effectiveWeights.map((weight) => (weight / effectiveTotal) * roundedTotal);
+  const amounts = exactAmounts.map(Math.floor);
+  const remainder = roundedTotal - amounts.reduce((sum, amount) => sum + amount, 0);
+  const remainderOrder = exactAmounts
+    .map((amount, index) => ({ index, fraction: amount - Math.floor(amount) }))
+    .sort((a, b) => b.fraction - a.fraction || a.index - b.index);
+
+  for (let index = 0; index < remainder; index += 1) {
+    amounts[remainderOrder[index % remainderOrder.length].index] += 1;
+  }
+
+  return amounts;
+};
+
+const hydrateOrganizations = (causeArea: DistributionCauseArea, amount: number) => {
+  const organizations = clone(causeArea.organizations);
+  if (organizations.every((organization) => isAmount(organization.amount))) return organizations;
+
+  const amounts = allocateTotal(amount, organizations);
+  return organizations.map((organization, index) => ({ ...organization, amount: amounts[index] }));
+};
+
+export const hydrateDistributionAmounts = (
+  distribution: Distribution,
+  donationAmount: number,
+): Distribution => {
+  const next = clone(distribution);
+  const causeAreaAmounts = next.causeAreas.every((causeArea) => isAmount(causeArea.amount))
+    ? next.causeAreas.map((causeArea) => causeArea.amount as number)
+    : allocateTotal(donationAmount, next.causeAreas);
+
+  next.causeAreas = next.causeAreas.map((causeArea, index) => {
+    const amount = causeAreaAmounts[index];
+    return {
+      ...causeArea,
+      amount,
+      organizations: hydrateOrganizations(causeArea, amount),
+    };
+  });
+
+  return next;
+};
+
+export const prepareDistributionForSave = (
+  distribution: Distribution,
+  donationAmount: number,
+  standardOrganizationIds: Map<number, number> = new Map(),
+): Distribution => {
+  if (!Number.isInteger(donationAmount) || donationAmount <= 0) {
+    throw new Error("Donation amount must be a positive whole number");
+  }
+
+  const activeCauseAreas = distribution.causeAreas.filter(
+    (causeArea) => isAmount(causeArea.amount) && causeArea.amount > 0,
+  );
+  const causeAreaTotal = activeCauseAreas.reduce(
+    (sum, causeArea) => sum + (causeArea.amount as number),
+    0,
+  );
+
+  if (causeAreaTotal !== donationAmount) {
+    throw new Error("Cause area amounts must sum to donation amount");
+  }
+
+  const causeAreaShares = distributeSharesWithRemainder(
+    activeCauseAreas.map((causeArea) => ({ id: causeArea.id, amount: causeArea.amount as number })),
+  );
+  const causeAreaShareById = new Map(
+    causeAreaShares.map((causeArea) => [causeArea.id, causeArea.percentageShare]),
+  );
+
+  return {
+    ...clone(distribution),
+    causeAreas: activeCauseAreas.map((causeArea) => {
+      const amount = causeArea.amount as number;
+      const standardOrganizationId = standardOrganizationIds.get(causeArea.id);
+      const standardOrganization = causeArea.organizations.find(
+        (organization) => organization.id === standardOrganizationId,
+      );
+      const organizations =
+        causeArea.standardSplit && standardOrganizationId !== undefined
+          ? [
+              {
+                ...standardOrganization,
+                id: standardOrganizationId,
+                percentageShare: "100",
+                amount,
+              },
+            ]
+          : causeArea.standardSplit
+          ? hydrateOrganizations(causeArea, amount)
+          : causeArea.organizations;
+      const activeOrganizations = organizations.filter(
+        (organization) => isAmount(organization.amount) && organization.amount > 0,
+      );
+      const organizationTotal = activeOrganizations.reduce(
+        (sum, organization) => sum + (organization.amount as number),
+        0,
+      );
+
+      if (organizationTotal !== amount) {
+        throw new Error("Organization amounts must sum to cause area amount");
+      }
+
+      const organizationShares = distributeSharesWithRemainder(
+        activeOrganizations.map((organization) => ({
+          id: organization.id,
+          amount: organization.amount as number,
+        })),
+      );
+      const organizationShareById = new Map(
+        organizationShares.map((organization) => [organization.id, organization.percentageShare]),
+      );
+
+      return {
+        ...causeArea,
+        amount,
+        percentageShare: causeAreaShareById.get(causeArea.id) as string,
+        organizations: activeOrganizations.map((organization) => ({
+          ...organization,
+          amount: organization.amount as number,
+          percentageShare: organizationShareById.get(organization.id) as string,
+        })),
+      };
+    }),
+  };
+};

--- a/components/profile/shared/distributionAmounts.ts
+++ b/components/profile/shared/distributionAmounts.ts
@@ -7,8 +7,11 @@ const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
 const isAmount = (value: unknown): value is number =>
   typeof value === "number" && Number.isFinite(value) && value >= 0;
 
-export const isAllocationVisible = (isActive: boolean | undefined, savedAmount?: number) =>
-  isActive !== false || (savedAmount ?? 0) > 0;
+export const isAllocationVisible = (
+  isActive: boolean | undefined,
+  savedAmount?: number,
+  standardPercentageShare?: number,
+) => isActive !== false || (savedAmount ?? 0) > 0 || (standardPercentageShare ?? 0) > 0;
 
 export const orderDistributionCauseAreas = (
   causeAreas: DistributionCauseArea[],

--- a/components/profile/shared/lists/agreementList/AgreementDetails.tsx
+++ b/components/profile/shared/lists/agreementList/AgreementDetails.tsx
@@ -32,6 +32,13 @@ import {
 } from "./multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails";
 import { DatePickerInputConfiguration } from "../../../../shared/components/DatePicker/DatePickerInput";
 import { AgreementTypes } from "./AgreementList";
+import {
+  getStandardOrganizationId,
+  getStandardOrganizationIds,
+  hydrateDistributionAmounts,
+  prepareDistributionForSave,
+  setStandardCauseAreaAmount,
+} from "../../distributionAmounts";
 
 export type AgreementDetailsConfiguration = {
   save_button_text: string;
@@ -85,18 +92,18 @@ export const AgreementDetails: React.FC<{
   const { getAccessTokenSilently, user } = useAuth0();
   const { mutate } = useSWRConfig();
   // Parse and stringify to make a deep copy of the object
-  const [distribution, setDistribution] = useState<Distribution>(
-    JSON.parse(JSON.stringify(inputDistribution)),
+  const [distribution, setDistribution] = useState<Distribution>(() =>
+    hydrateDistributionAmounts(inputDistribution, inputSum),
   );
-  const [lastSavedDistribution, setLastSavedDistribution] = useState<Distribution>(
-    JSON.parse(JSON.stringify(inputDistribution)),
+  const [lastSavedDistribution, setLastSavedDistribution] = useState<Distribution>(() =>
+    hydrateDistributionAmounts(inputDistribution, inputSum),
   );
   const [day, setDay] = useState(inputDate);
   const [sum, setSum] = useState(inputSum);
 
   useEffect(() => {
-    setLastSavedDistribution(JSON.parse(JSON.stringify(inputDistribution)));
-  }, [inputDistribution]);
+    setLastSavedDistribution(hydrateDistributionAmounts(inputDistribution, inputSum));
+  }, [inputDistribution, inputSum]);
 
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [loadingChanges, setLoadingChanges] = useState(false);
@@ -122,7 +129,7 @@ export const AgreementDetails: React.FC<{
       );
 
       if (missingCauseAreas.length > 0) {
-        const newDistribution = JSON.parse(JSON.stringify(inputDistribution));
+        const newDistribution = hydrateDistributionAmounts(inputDistribution, inputSum);
         missingCauseAreas.forEach((id) => {
           const systemCauseArea = systemCauseAreas.find((causeArea) => causeArea.id === id);
           if (systemCauseArea) {
@@ -131,10 +138,12 @@ export const AgreementDetails: React.FC<{
               name: systemCauseArea.name,
               standardSplit: true,
               percentageShare: "0",
+              amount: 0,
               organizations: systemCauseArea.organizations.map((org) => {
                 return {
                   id: org.id,
                   percentageShare: org.standardShare?.toString() || "0",
+                  amount: 0,
                 };
               }),
             });
@@ -143,13 +152,34 @@ export const AgreementDetails: React.FC<{
         setDistribution(newDistribution);
       }
     }
-  }, [systemCauseAreas, inputDistribution]);
+  }, [systemCauseAreas, inputDistribution, inputSum]);
+
+  const changeSum = (nextSum: number) => {
+    setDistribution((current) => {
+      const causeArea = current.causeAreas[0];
+      const systemCauseArea = systemCauseAreas?.find((system) => system.id === causeArea.id);
+      const standardOrganizationId = systemCauseArea
+        ? getStandardOrganizationId(systemCauseArea)
+        : undefined;
+      if (standardOrganizationId === undefined) return current;
+      return {
+        ...current,
+        causeAreas: [setStandardCauseAreaAmount(causeArea, nextSum, standardOrganizationId)],
+      };
+    });
+    setSum(nextSum);
+  };
 
   const save = async () => {
     const token = await getAccessTokenSilently();
     const distributionChanged =
       JSON.stringify(distribution) !== JSON.stringify(lastSavedDistribution);
-    const sumChanged = sum !== inputSum;
+    const agreementSum =
+      systemCauseAreas &&
+      (systemCauseAreas.length > 1 || !distribution.causeAreas[0]?.standardSplit)
+        ? distribution.causeAreas.reduce((total, causeArea) => total + (causeArea.amount ?? 0), 0)
+        : sum;
+    const sumChanged = agreementSum !== inputSum;
     const dayChanged = day !== inputDate;
 
     if (!distributionChanged && !dayChanged && !sumChanged) {
@@ -159,21 +189,33 @@ export const AgreementDetails: React.FC<{
 
     if (!user) throw new Error("User is not logged in");
 
+    let distributionPayload: Distribution;
+    try {
+      distributionPayload = prepareDistributionForSave(
+        distribution,
+        agreementSum,
+        getStandardOrganizationIds(systemCauseAreas ?? []),
+      );
+    } catch {
+      failureToast(configuration.toasts_configuration.failure_text);
+      return;
+    }
+
     setLoadingChanges(true);
 
     if (type == "Vipps") {
       let result = null;
 
-      if (distributionChanged) {
-        result = await updateVippsAgreementDistribution(endpoint, distribution, token);
+      if (sumChanged) {
+        result = await updateVippsAgreementPrice(endpoint, agreementSum, token);
       }
 
       if (dayChanged) {
         result = await updateVippsAgreementDay(endpoint, day, token);
       }
 
-      if (sumChanged) {
-        result = await updateVippsAgreementPrice(endpoint, sum, token);
+      if (distributionChanged || sumChanged) {
+        result = await updateVippsAgreementDistribution(endpoint, distributionPayload, token);
       }
 
       if (result != null) {
@@ -188,16 +230,16 @@ export const AgreementDetails: React.FC<{
     } else if (type == "AvtaleGiro") {
       let result = null;
 
-      if (distributionChanged) {
-        result = await updateAvtalegiroAgreementDistribution(endpoint, distribution, token);
+      if (sumChanged) {
+        result = await updateAvtaleagreementAmount(endpoint, agreementSum * 100, token);
       }
 
       if (dayChanged) {
         result = await updateAvtaleagreementPaymentDay(endpoint, day, token);
       }
 
-      if (sumChanged) {
-        result = await updateAvtaleagreementAmount(endpoint, sum * 100, token);
+      if (distributionChanged || sumChanged) {
+        result = await updateAvtalegiroAgreementDistribution(endpoint, distributionPayload, token);
       }
 
       if (result !== null) {
@@ -212,9 +254,9 @@ export const AgreementDetails: React.FC<{
     } else if (type == "AutoGiro") {
       let result = await updateAutoGiroAgreement(
         endpoint,
-        distributionChanged ? distribution : null,
+        distributionChanged || sumChanged ? distributionPayload : null,
         dayChanged ? day : null,
-        sumChanged ? sum : null,
+        sumChanged ? agreementSum : null,
         token,
       );
 
@@ -302,11 +344,12 @@ export const AgreementDetails: React.FC<{
         {systemCauseAreas.length === 1 && (
           <AgreementSingleCauseAreaDetails
             distribution={distribution}
+            savedDistribution={lastSavedDistribution}
             setDistribution={setDistribution}
             day={day}
             setDay={setDay}
             sum={sum}
-            setSum={setSum}
+            setSum={changeSum}
             taxUnits={taxUnits}
             dateSelectorConfig={configuration.date_selector_configuration}
           ></AgreementSingleCauseAreaDetails>
@@ -316,11 +359,10 @@ export const AgreementDetails: React.FC<{
           <AgreementMultipleCauseAreaDetails
             systemCauseAreas={systemCauseAreas}
             distribution={distribution}
+            savedDistribution={lastSavedDistribution}
             setDistribution={setDistribution}
             day={day}
             setDay={setDay}
-            sum={sum}
-            setSum={setSum}
             taxUnits={taxUnits}
             configuration={configuration.distribution_configuration}
             dateSelectorConfig={configuration.date_selector_configuration}

--- a/components/profile/shared/lists/agreementList/AgreementDetails.tsx
+++ b/components/profile/shared/lists/agreementList/AgreementDetails.tsx
@@ -349,7 +349,8 @@ export const AgreementDetails: React.FC<{
             day={day}
             setDay={setDay}
             sum={sum}
-            setSum={changeSum}
+            setSum={setSum}
+            onSumChange={changeSum}
             taxUnits={taxUnits}
             dateSelectorConfig={configuration.date_selector_configuration}
           ></AgreementSingleCauseAreaDetails>

--- a/components/profile/shared/lists/agreementList/DKAgreementDetails.module.scss
+++ b/components/profile/shared/lists/agreementList/DKAgreementDetails.module.scss
@@ -67,44 +67,32 @@
 }
 
 .multiLayout {
-  display: grid;
-  grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);
-  column-gap: 3rem;
-
-  & > .values {
-    flex-direction: column;
-    align-items: stretch;
-    row-gap: 1.5rem;
-
-    & > div {
-      width: 100%;
-      min-width: 0;
-    }
-  }
+  display: flex;
+  flex-direction: column;
+  row-gap: 2rem;
 }
 
 .causeAreas {
-  & > div {
-    margin-top: 1.5rem;
-  }
-
-  & > div:first-child {
-    margin-top: 0;
-  }
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 2rem;
 }
 
 .distributionCauseAreaInputHeader {
   display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
   margin-bottom: 1rem;
 
   & > div {
     display: flex;
     flex-direction: row;
     align-items: center;
+    justify-content: space-between;
     gap: 1rem;
+    width: 100%;
+    min-height: 26px;
   }
 }
 
@@ -141,6 +129,7 @@
 .amountInput,
 .percentageInput,
 .calculatedAmount {
+  display: block;
   background: var(--secondary);
   color: var(--primary);
   font-family: "ESKlarheitGrotesk";
@@ -152,11 +141,7 @@
   width: 100%;
 }
 
-.calculatedAmount {
-  display: block;
-}
-
-@media only screen and (max-width: 1180px) {
+@media only screen and (max-width: 720px) {
   .values {
     flex-direction: column;
     align-items: stretch;
@@ -173,11 +158,6 @@
 
   .valuesSmartDistributionToggle {
     justify-content: space-between;
-  }
-
-  .multiLayout {
-    grid-template-columns: 1fr;
-    row-gap: 2rem;
   }
 
   .actions {

--- a/components/profile/shared/lists/agreementList/DKAgreementDetails.module.scss
+++ b/components/profile/shared/lists/agreementList/DKAgreementDetails.module.scss
@@ -70,6 +70,17 @@
   display: grid;
   grid-template-columns: minmax(0, 24rem) minmax(0, 1fr);
   column-gap: 3rem;
+
+  & > .values {
+    flex-direction: column;
+    align-items: stretch;
+    row-gap: 1.5rem;
+
+    & > div {
+      width: 100%;
+      min-width: 0;
+    }
+  }
 }
 
 .causeAreas {
@@ -128,7 +139,8 @@
 }
 
 .amountInput,
-.percentageInput {
+.percentageInput,
+.calculatedAmount {
   background: var(--secondary);
   color: var(--primary);
   font-family: "ESKlarheitGrotesk";
@@ -138,6 +150,10 @@
   border: 1px solid var(--primary);
   padding: 0.5rem 1.2rem;
   width: 100%;
+}
+
+.calculatedAmount {
+  display: block;
 }
 
 @media only screen and (max-width: 1180px) {

--- a/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
+++ b/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
@@ -344,9 +344,12 @@ export const DKAgreementDetails: React.FC<{
                   <span>kr</span>
                 </>
               ) : (
-                <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
-                  {formatSum((singleCauseArea.amount ?? 0).toString())} kr
-                </output>
+                <>
+                  <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
+                    {formatSum((singleCauseArea.amount ?? 0).toString())}
+                  </output>
+                  <span>kr</span>
+                </>
               )}
             </div>
 
@@ -363,7 +366,7 @@ export const DKAgreementDetails: React.FC<{
             </div>
 
             <div className={style.valuesSmartDistributionToggle}>
-              <span>
+              <span className="caption">
                 {configuration.distribution_configuration?.smart_distribution_label ||
                   "Smart fordeling"}
               </span>
@@ -410,8 +413,9 @@ export const DKAgreementDetails: React.FC<{
 
             <div className={style.valuesAmountContainer}>
               <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
-                {formatSum(distributionAmount.toString())} kr
+                {formatSum(distributionAmount.toString())}
               </output>
+              <span>kr</span>
             </div>
 
             <div className={style.valuesTaxUnitSelectorContainer}>
@@ -440,27 +444,29 @@ export const DKAgreementDetails: React.FC<{
                 <div key={`dist-${causeArea.id}`}>
                   <div className={style.distributionCauseAreaInputHeader}>
                     <span>{causeArea.name}</span>
-                    {causeAreaHasMultipleOrganizations && (
-                      <div className={style.valuesSmartDistributionToggle}>
-                        <span>
-                          {configuration.distribution_configuration?.smart_distribution_label ||
-                            "Smart fordeling"}
-                        </span>
-                        <Toggle
-                          active={causeArea.standardSplit}
-                          onChange={(active) =>
-                            setDistribution({
-                              ...distribution,
-                              causeAreas: distribution.causeAreas.map((current) =>
-                                current.id === causeArea.id
-                                  ? setCauseAreaStandardSplit(current, active)
-                                  : { ...current },
-                              ),
-                            })
-                          }
-                        />
-                      </div>
-                    )}
+                    <div className={style.valuesSmartDistributionToggle}>
+                      {causeAreaHasMultipleOrganizations && (
+                        <>
+                          <span className="caption">
+                            {configuration.distribution_configuration?.smart_distribution_label ||
+                              "Smart fordeling"}
+                          </span>
+                          <Toggle
+                            active={causeArea.standardSplit}
+                            onChange={(active) =>
+                              setDistribution({
+                                ...distribution,
+                                causeAreas: distribution.causeAreas.map((current) =>
+                                  current.id === causeArea.id
+                                    ? setCauseAreaStandardSplit(current, active)
+                                    : { ...current },
+                                ),
+                              })
+                            }
+                          />
+                        </>
+                      )}
+                    </div>
                   </div>
 
                   <div className={style.distributionCauseAreaInputPercentageShare}>
@@ -490,9 +496,12 @@ export const DKAgreementDetails: React.FC<{
                         <span>kr</span>
                       </>
                     ) : (
-                      <output className={style.calculatedAmount} data-cy="cause-area-input">
-                        {formatSum((causeArea.amount ?? 0).toString())} kr
-                      </output>
+                      <>
+                        <output className={style.calculatedAmount} data-cy="cause-area-input">
+                          {formatSum((causeArea.amount ?? 0).toString())}
+                        </output>
+                        <span>kr</span>
+                      </>
                     )}
                   </div>
 

--- a/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
+++ b/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
@@ -310,7 +310,11 @@ export const DKAgreementDetails: React.FC<{
     const systemCauseArea = systemCauseAreas.find((current) => current.id === causeArea.id);
     const savedAmount =
       lastSavedDistribution?.causeAreas.find((saved) => saved.id === causeArea.id)?.amount ?? 0;
-    return isAllocationVisible(systemCauseArea ? systemCauseArea.isActive : false, savedAmount);
+    return isAllocationVisible(
+      systemCauseArea ? systemCauseArea.isActive : false,
+      savedAmount,
+      systemCauseArea?.standardPercentageShare,
+    );
   });
 
   return (

--- a/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
+++ b/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
@@ -29,6 +29,16 @@ import { DKAgreementMembershipLine } from "./DKAgreementMembershipLine";
 import { distributionTargetsMembershipFee, getDKMembershipDisplay } from "./dkMembershipDisplay";
 import { getUserId } from "../../../../../lib/user";
 import { cancelDKAgreement, updateDKAgreement } from "./_queries";
+import {
+  getStandardOrganizationId,
+  getStandardOrganizationIds,
+  hydrateDistributionAmounts,
+  isAllocationVisible,
+  orderDistributionCauseAreas,
+  prepareDistributionForSave,
+  setCauseAreaStandardSplit,
+  setStandardCauseAreaAmount,
+} from "../../distributionAmounts";
 
 import style from "./DKAgreementDetails.module.scss";
 
@@ -56,11 +66,11 @@ export const DKAgreementDetails: React.FC<{
   const { getAccessTokenSilently, user } = useAuth0();
   const { mutate } = useSWRConfig();
 
-  const [distribution, setDistribution] = useState<Distribution | null>(
-    cloneDistribution(inputDistribution),
+  const [distribution, setDistribution] = useState<Distribution | null>(() =>
+    inputDistribution ? hydrateDistributionAmounts(inputDistribution, inputSum) : null,
   );
-  const [lastSavedDistribution, setLastSavedDistribution] = useState<Distribution | null>(
-    cloneDistribution(inputDistribution),
+  const [lastSavedDistribution, setLastSavedDistribution] = useState<Distribution | null>(() =>
+    inputDistribution ? hydrateDistributionAmounts(inputDistribution, inputSum) : null,
   );
   const [day, setDay] = useState(inputDate);
   const [sum, setSum] = useState(inputSum);
@@ -75,9 +85,12 @@ export const DKAgreementDetails: React.FC<{
   } = useCauseAreas(getAccessTokenSilently);
 
   useEffect(() => {
-    setDistribution(cloneDistribution(inputDistribution));
-    setLastSavedDistribution(cloneDistribution(inputDistribution));
-  }, [inputDistribution]);
+    const hydrated = inputDistribution
+      ? hydrateDistributionAmounts(inputDistribution, inputSum)
+      : null;
+    setDistribution(hydrated);
+    setLastSavedDistribution(hydrated);
+  }, [inputDistribution, inputSum]);
 
   useEffect(() => {
     setDay(inputDate);
@@ -135,7 +148,13 @@ export const DKAgreementDetails: React.FC<{
     const token = await getAccessTokenSilently();
     const distributionChanged =
       JSON.stringify(distribution) !== JSON.stringify(lastSavedDistribution);
-    const sumChanged = sum !== inputSum;
+    const agreementSum =
+      systemCauseAreas &&
+      distribution &&
+      (systemCauseAreas.length > 1 || !distribution.causeAreas[0]?.standardSplit)
+        ? distribution.causeAreas.reduce((total, causeArea) => total + (causeArea.amount ?? 0), 0)
+        : sum;
+    const sumChanged = agreementSum !== inputSum;
     const dayChanged = canEditDate && day !== inputDate;
 
     if (!distributionChanged && !sumChanged && !dayChanged) {
@@ -143,14 +162,28 @@ export const DKAgreementDetails: React.FC<{
       return;
     }
 
+    let distributionPayload: Distribution | null = null;
+    if (distribution) {
+      try {
+        distributionPayload = prepareDistributionForSave(
+          distribution,
+          agreementSum,
+          getStandardOrganizationIds(systemCauseAreas ?? []),
+        );
+      } catch {
+        failureToast(configuration.toasts_configuration.failure_text);
+        return;
+      }
+    }
+
     setLoadingChanges(true);
 
     const result = await updateDKAgreement(
       getUserId(user),
       agreementId,
-      distributionChanged ? distribution : null,
+      distributionChanged || sumChanged ? distributionPayload : null,
       dayChanged ? day : null,
-      sumChanged ? sum : null,
+      sumChanged ? agreementSum : null,
       token,
     );
 
@@ -163,6 +196,23 @@ export const DKAgreementDetails: React.FC<{
     }
 
     setLoadingChanges(false);
+  };
+
+  const changeSum = (nextSum: number) => {
+    setDistribution((current) => {
+      if (!current) return current;
+      const causeArea = current.causeAreas[0];
+      const systemCauseArea = systemCauseAreas?.find((system) => system.id === causeArea.id);
+      const standardOrganizationId = systemCauseArea
+        ? getStandardOrganizationId(systemCauseArea)
+        : undefined;
+      if (standardOrganizationId === undefined) return current;
+      return {
+        ...current,
+        causeAreas: [setStandardCauseAreaAmount(causeArea, nextSum, standardOrganizationId)],
+      };
+    });
+    setSum(nextSum);
   };
 
   const cancel = async () => {
@@ -248,6 +298,20 @@ export const DKAgreementDetails: React.FC<{
   }
 
   const isSingleCauseArea = systemCauseAreas.length === 1;
+  const singleCauseArea = distribution.causeAreas[0];
+  const distributionAmount = distribution.causeAreas.reduce(
+    (total, causeArea) => total + (causeArea.amount ?? 0),
+    0,
+  );
+  const visibleCauseAreas = orderDistributionCauseAreas(
+    distribution.causeAreas,
+    systemCauseAreas,
+  ).filter((causeArea) => {
+    const systemCauseArea = systemCauseAreas.find((current) => current.id === causeArea.id);
+    const savedAmount =
+      lastSavedDistribution?.causeAreas.find((saved) => saved.id === causeArea.id)?.amount ?? 0;
+    return isAllocationVisible(systemCauseArea ? systemCauseArea.isActive : false, savedAmount);
+  });
 
   return (
     <div className={style.wrapper} data-cy="agreement-list-details">
@@ -268,14 +332,22 @@ export const DKAgreementDetails: React.FC<{
             )}
 
             <div className={style.valuesAmountContainer}>
-              <input
-                className={style.amountInput}
-                type="text"
-                value={formatSum(sum.toString())}
-                onChange={(e) => setSum(parseSum(e.currentTarget.value))}
-                data-cy="agreement-list-amount-input"
-              />
-              <span>kr</span>
+              {singleCauseArea.standardSplit ? (
+                <>
+                  <input
+                    className={style.amountInput}
+                    type="text"
+                    value={formatSum(sum.toString())}
+                    onChange={(e) => changeSum(parseSum(e.currentTarget.value))}
+                    data-cy="agreement-list-amount-input"
+                  />
+                  <span>kr</span>
+                </>
+              ) : (
+                <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
+                  {formatSum((singleCauseArea.amount ?? 0).toString())} kr
+                </output>
+              )}
             </div>
 
             <div className={style.valuesTaxUnitSelectorContainer}>
@@ -296,24 +368,23 @@ export const DKAgreementDetails: React.FC<{
                   "Smart fordeling"}
               </span>
               <Toggle
-                active={distribution.causeAreas[0].standardSplit}
-                onChange={(active) =>
-                  setDistribution({
-                    ...distribution,
-                    causeAreas: [{ ...distribution.causeAreas[0], standardSplit: active }],
-                  })
-                }
+                active={singleCauseArea.standardSplit}
+                onChange={(active) => {
+                  const nextCauseArea = setCauseAreaStandardSplit(singleCauseArea, active);
+                  setDistribution({ ...distribution, causeAreas: [nextCauseArea] });
+                  setSum(nextCauseArea.amount ?? 0);
+                }}
               />
             </div>
           </div>
 
-          <AnimateHeight
-            height={!distribution.causeAreas[0].standardSplit ? "auto" : 0}
-            animateOpacity={true}
-          >
+          <AnimateHeight height={!singleCauseArea.standardSplit ? "auto" : 0} animateOpacity={true}>
             <div className={style.singleCauseAreaDistribution}>
               <DistributionController
-                causeArea={distribution.causeAreas[0]}
+                causeArea={singleCauseArea}
+                savedCauseArea={lastSavedDistribution?.causeAreas.find(
+                  (saved) => saved.id === singleCauseArea.id,
+                )}
                 onChange={(causeArea) =>
                   setDistribution({
                     ...distribution,
@@ -338,14 +409,9 @@ export const DKAgreementDetails: React.FC<{
             )}
 
             <div className={style.valuesAmountContainer}>
-              <input
-                className={style.amountInput}
-                type="text"
-                value={formatSum(sum.toString())}
-                onChange={(e) => setSum(parseSum(e.currentTarget.value))}
-                data-cy="agreement-list-amount-input"
-              />
-              <span>kr</span>
+              <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
+                {formatSum(distributionAmount.toString())} kr
+              </output>
             </div>
 
             <div className={style.valuesTaxUnitSelectorContainer}>
@@ -362,10 +428,13 @@ export const DKAgreementDetails: React.FC<{
           </div>
 
           <div className={style.causeAreas}>
-            {distribution.causeAreas.map((causeArea) => {
+            {visibleCauseAreas.map((causeArea) => {
               const systemCauseArea = systemCauseAreas.find((item) => item.id === causeArea.id);
               const causeAreaHasMultipleOrganizations =
                 (systemCauseArea?.organizations.length || 0) > 1;
+              const standardOrganizationId = systemCauseArea
+                ? getStandardOrganizationId(systemCauseArea)
+                : undefined;
 
               return (
                 <div key={`dist-${causeArea.id}`}>
@@ -384,7 +453,7 @@ export const DKAgreementDetails: React.FC<{
                               ...distribution,
                               causeAreas: distribution.causeAreas.map((current) =>
                                 current.id === causeArea.id
-                                  ? { ...current, standardSplit: active }
+                                  ? setCauseAreaStandardSplit(current, active)
                                   : { ...current },
                               ),
                             })
@@ -395,24 +464,36 @@ export const DKAgreementDetails: React.FC<{
                   </div>
 
                   <div className={style.distributionCauseAreaInputPercentageShare}>
-                    <input
-                      className={style.percentageInput}
-                      type="text"
-                      value={Math.round(parseFloat(causeArea.percentageShare)).toString() || "0"}
-                      onChange={(e) => {
-                        const percentageShare = parseFloat(e.target.value) || 0;
-                        setDistribution({
-                          ...distribution,
-                          causeAreas: distribution.causeAreas.map((current) =>
-                            current.id === causeArea.id
-                              ? { ...current, percentageShare: percentageShare.toFixed(0) }
-                              : { ...current },
-                          ),
-                        });
-                      }}
-                      data-cy="cause-area-input"
-                    />
-                    <span>%</span>
+                    {causeArea.standardSplit ? (
+                      <>
+                        <input
+                          className={style.percentageInput}
+                          type="text"
+                          value={causeArea.amount ?? 0}
+                          onChange={(e) => {
+                            const amount = Math.max(0, parseInt(e.target.value, 10) || 0);
+                            setDistribution({
+                              ...distribution,
+                              causeAreas: distribution.causeAreas.map((current) =>
+                                current.id === causeArea.id && standardOrganizationId !== undefined
+                                  ? setStandardCauseAreaAmount(
+                                      current,
+                                      amount,
+                                      standardOrganizationId,
+                                    )
+                                  : { ...current },
+                              ),
+                            });
+                          }}
+                          data-cy="cause-area-input"
+                        />
+                        <span>kr</span>
+                      </>
+                    ) : (
+                      <output className={style.calculatedAmount} data-cy="cause-area-input">
+                        {formatSum((causeArea.amount ?? 0).toString())} kr
+                      </output>
+                    )}
                   </div>
 
                   <AnimateHeight
@@ -422,6 +503,9 @@ export const DKAgreementDetails: React.FC<{
                     <div className={style.distributionCauseAreaInputContainer}>
                       <DistributionController
                         causeArea={causeArea}
+                        savedCauseArea={lastSavedDistribution?.causeAreas.find(
+                          (saved) => saved.id === causeArea.id,
+                        )}
                         onChange={(nextCauseArea) =>
                           setDistribution({
                             ...distribution,
@@ -508,10 +592,12 @@ const addMissingCauseAreas = (distribution: Distribution, systemCauseAreas: Caus
       name: causeArea.name,
       standardSplit: true,
       percentageShare: "0",
+      amount: 0,
       organizations: causeArea.organizations.map((organization) => ({
         id: organization.id,
         name: organization.name,
         percentageShare: organization.standardShare?.toString() || "0",
+        amount: 0,
       })),
     });
   });
@@ -532,7 +618,7 @@ const formatSum = (sum: string) => {
   return parts.length === 2 ? formatted + "." + parts[1] : formatted;
 };
 
-const parseSum = (sum: string) => parseFloat(sum.replace(/ /g, "")) || 0;
+const parseSum = (sum: string) => parseInt(sum.replace(/ /g, ""), 10) || 0;
 
 const successToast = (text: string) =>
   toast.success(text, { icon: <Check size={24} color={"black"} /> });

--- a/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreaDetails.module.scss
+++ b/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreaDetails.module.scss
@@ -1,47 +1,31 @@
 .wrapper {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  column-gap: 3rem;
+  display: flex;
+  flex-direction: column;
+  row-gap: 2rem;
 }
 
 .values {
   display: flex;
-  flex-direction: column;
-  row-gap: 1.5em;
+  flex-direction: row;
+  column-gap: 1.5rem;
   font-size: 1rem;
 
   & > div {
     position: relative;
     display: inline-flex;
     flex-direction: row;
+    flex: 1 1 0;
+    min-width: 0;
     align-items: center;
 
-    &.valuesDatePickerContainer {
+    &.valuesDatePickerContainer > div,
+    &.valuesTaxUnitSelectorContainer > div {
       width: 100%;
-
-      & > div {
-        width: 100%;
-      }
     }
 
-    &.valuesAmountContainer {
-      input {
-        width: 100%;
-      }
-
-      /* Currency label positioned to the right in the field */
-      span {
-        position: absolute;
-        right: 1.2rem;
-      }
-    }
-
-    &.valuesTaxUnitSelectorContainer {
-      width: 100%;
-
-      & > div {
-        width: 100%;
-      }
+    &.valuesAmountContainer span {
+      position: absolute;
+      right: 1.2rem;
     }
   }
 
@@ -61,26 +45,25 @@
 }
 
 .causeAreas {
-  & > div {
-    margin-top: 1.5rem;
-  }
-
-  & div:first-child {
-    margin-top: 0;
-  }
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  gap: 2rem;
 
   .distributionCauseAreaInputHeader {
     display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
     margin-bottom: 1rem;
 
     & > div {
       display: flex;
       flex-direction: row;
       align-items: center;
+      justify-content: space-between;
       gap: 1rem;
+      width: 100%;
+      min-height: 26px;
     }
   }
 
@@ -92,6 +75,7 @@
 
     input,
     .calculatedAmount {
+      display: block;
       background: var(--secondary);
       color: var(--primary);
       font-family: "ESKlarheitGrotesk";
@@ -101,10 +85,6 @@
       border: 1px solid var(--primary);
       padding: 0.5rem 1.2rem;
       width: 100%;
-    }
-
-    .calculatedAmount {
-      display: block;
     }
 
     span {
@@ -118,44 +98,14 @@
   }
 }
 
-@media only screen and (max-width: 1180px) {
-  .wrapper {
-    grid-template-columns: 1fr;
-    column-gap: 0;
-    row-gap: 2rem;
+@media only screen and (max-width: 720px) {
+  .values {
+    flex-direction: column;
+    row-gap: 1.5rem;
 
-    .values {
-      flex-direction: column;
-      row-gap: 1.5em;
-      font-size: 1rem;
-
-      input {
-        width: 100%;
-      }
-
-      & > div {
-        &.valuesDatePickerContainer {
-          width: 100%;
-
-          & > div {
-            width: 100%;
-          }
-        }
-
-        &.valuesAmountContainer {
-          input {
-            width: 100%;
-          }
-        }
-
-        &.valuesTaxUnitSelectorContainer {
-          width: 100%;
-
-          & > div {
-            width: 100%;
-          }
-        }
-      }
+    & > div {
+      width: 100%;
+      flex: initial;
     }
   }
 }

--- a/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreaDetails.module.scss
+++ b/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreaDetails.module.scss
@@ -45,7 +45,9 @@
     }
   }
 
-  input {
+  input,
+  .calculatedAmount {
+    display: block;
     background: var(--secondary);
     color: var(--primary);
     font-family: "ESKlarheitGrotesk";
@@ -88,7 +90,8 @@
     flex-direction: row;
     align-items: center;
 
-    input {
+    input,
+    .calculatedAmount {
       background: var(--secondary);
       color: var(--primary);
       font-family: "ESKlarheitGrotesk";
@@ -98,6 +101,10 @@
       border: 1px solid var(--primary);
       padding: 0.5rem 1.2rem;
       width: 100%;
+    }
+
+    .calculatedAmount {
+      display: block;
     }
 
     span {

--- a/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails.tsx
+++ b/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails.tsx
@@ -12,6 +12,13 @@ import { useState } from "react";
 
 import style from "./AgreementMultipleCauseAreaDetails.module.scss";
 import { CauseArea } from "../../../../../shared/components/Widget/types/CauseArea";
+import {
+  getStandardOrganizationId,
+  isAllocationVisible,
+  orderDistributionCauseAreas,
+  setCauseAreaStandardSplit,
+  setStandardCauseAreaAmount,
+} from "../../../distributionAmounts";
 
 export type AgreementMultipleCauseAreaDetailsConfiguration = {
   smart_distribution_label: string;
@@ -20,22 +27,20 @@ export type AgreementMultipleCauseAreaDetailsConfiguration = {
 export const AgreementMultipleCauseAreaDetails: React.FC<{
   systemCauseAreas: CauseArea[];
   distribution: Distribution;
+  savedDistribution: Distribution;
   setDistribution: (dist: Distribution) => void;
   day: number;
   setDay: (day: number) => void;
-  sum: number;
-  setSum: (sum: number) => void;
   taxUnits: TaxUnit[];
   configuration: AgreementMultipleCauseAreaDetailsConfiguration;
   dateSelectorConfig: DatePickerInputConfiguration;
 }> = ({
   systemCauseAreas,
   distribution,
+  savedDistribution,
   setDistribution,
   day,
   setDay,
-  sum,
-  setSum,
   taxUnits,
   configuration,
   dateSelectorConfig,
@@ -43,6 +48,19 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
   const [addTaxUnitOpen, setAddTaxUnitOpen] = useState(false);
 
   const currentTaxUnit = taxUnits.find((unit) => unit.id === distribution.taxUnitId);
+  const distributionAmount = distribution.causeAreas.reduce(
+    (total, causeArea) => total + (causeArea.amount ?? 0),
+    0,
+  );
+  const visibleCauseAreas = orderDistributionCauseAreas(
+    distribution.causeAreas,
+    systemCauseAreas,
+  ).filter((causeArea) => {
+    const systemCauseArea = systemCauseAreas.find((current) => current.id === causeArea.id);
+    const savedAmount =
+      savedDistribution.causeAreas.find((saved) => saved.id === causeArea.id)?.amount ?? 0;
+    return isAllocationVisible(systemCauseArea ? systemCauseArea.isActive : false, savedAmount);
+  });
 
   return (
     <>
@@ -56,13 +74,9 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
             />
           </div>
           <div className={style.valuesAmountContainer}>
-            <input
-              type="text"
-              value={formatSum(sum.toString())}
-              onChange={(e) => setSum(parseSum(e.currentTarget.value))}
-              data-cy="agreement-list-amount-input"
-            />
-            <span>kr</span>
+            <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
+              {formatSum(distributionAmount.toString())} kr
+            </output>
           </div>
           <div className={style.valuesTaxUnitSelectorContainer}>
             <TaxUnitSelector
@@ -73,9 +87,13 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
           </div>
         </div>
         <div className={style.causeAreas}>
-          {distribution.causeAreas.map((causeArea, index) => {
+          {visibleCauseAreas.map((causeArea, index) => {
+            const systemCauseArea = systemCauseAreas.find((current) => current.id === causeArea.id);
             const causeAreaHasMultipleOrganizations =
-              (systemCauseAreas.find((c) => c.id === causeArea.id)?.organizations.length || 0) > 1;
+              (systemCauseArea?.organizations.length || 0) > 1;
+            const standardOrganizationId = systemCauseArea
+              ? getStandardOrganizationId(systemCauseArea)
+              : undefined;
             return (
               <div key={`dist-${causeArea.id}`}>
                 <div className={style.distributionCauseAreaInputHeader}>
@@ -88,13 +106,11 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
                         onChange={(active) =>
                           setDistribution({
                             ...distribution,
-                            causeAreas: distribution.causeAreas.map((c) => {
-                              if (causeArea && c.id === causeArea.id) {
-                                return { ...c, standardSplit: active };
-                              } else {
-                                return { ...c };
-                              }
-                            }),
+                            causeAreas: distribution.causeAreas.map((current) =>
+                              current.id === causeArea.id
+                                ? setCauseAreaStandardSplit(current, active)
+                                : { ...current },
+                            ),
                           })
                         }
                       />
@@ -102,26 +118,34 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
                   )}
                 </div>
                 <div className={style.distributionCauseAreaInputPercentageShare}>
-                  <input
-                    type="text"
-                    value={Math.round(parseFloat(causeArea.percentageShare)).toString() || 0}
-                    onChange={(e) => {
-                      const percentageShare = parseFloat(e.target.value) || 0;
-                      const causeAreas = [...distribution.causeAreas];
-                      const index = causeAreas.findIndex((c) => c.id === causeArea?.id);
-                      if (index === -1) {
-                        return;
-                      } else {
-                        causeAreas[index] = {
-                          ...causeAreas[index],
-                          percentageShare: percentageShare.toFixed(0),
-                        };
-                      }
-                      setDistribution({ ...distribution, causeAreas });
-                    }}
-                    data-cy="cause-area-input"
-                  />
-                  <span>%</span>
+                  {causeArea.standardSplit ? (
+                    <>
+                      <input
+                        type="text"
+                        value={causeArea.amount ?? 0}
+                        onChange={(e) => {
+                          const amount = Math.max(0, parseInt(e.target.value, 10) || 0);
+                          const causeAreas = [...distribution.causeAreas];
+                          const index = causeAreas.findIndex(
+                            (current) => current.id === causeArea.id,
+                          );
+                          if (index === -1 || standardOrganizationId === undefined) return;
+                          causeAreas[index] = setStandardCauseAreaAmount(
+                            causeAreas[index],
+                            amount,
+                            standardOrganizationId,
+                          );
+                          setDistribution({ ...distribution, causeAreas });
+                        }}
+                        data-cy="cause-area-input"
+                      />
+                      <span>kr</span>
+                    </>
+                  ) : (
+                    <output className={style.calculatedAmount} data-cy="cause-area-input">
+                      {formatSum((causeArea.amount ?? 0).toString())} kr
+                    </output>
+                  )}
                 </div>
                 <AnimateHeight
                   key={index}
@@ -131,6 +155,9 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
                   <div className={style.distributionCauseAreaInputContainer}>
                     <DistributionController
                       causeArea={causeArea}
+                      savedCauseArea={savedDistribution.causeAreas.find(
+                        (saved) => saved.id === causeArea.id,
+                      )}
                       onChange={(causeArea) => {
                         const causeAreas = [...distribution.causeAreas];
                         const index = causeAreas.findIndex((c) => c.id === causeArea.id);
@@ -171,11 +198,4 @@ const formatSum = (sum: string) => {
   const parts = sum.split(".");
   const formatted = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, " ");
   return parts.length === 2 ? formatted + "." + parts[1] : formatted;
-};
-
-/**
- * Strip thin seperator from sum and return a number.
- */
-const parseSum = (sum: string) => {
-  return parseFloat(sum.replace(/ /g, "")) || 0;
 };

--- a/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails.tsx
+++ b/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails.tsx
@@ -59,7 +59,11 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
     const systemCauseArea = systemCauseAreas.find((current) => current.id === causeArea.id);
     const savedAmount =
       savedDistribution.causeAreas.find((saved) => saved.id === causeArea.id)?.amount ?? 0;
-    return isAllocationVisible(systemCauseArea ? systemCauseArea.isActive : false, savedAmount);
+    return isAllocationVisible(
+      systemCauseArea ? systemCauseArea.isActive : false,
+      savedAmount,
+      systemCauseArea?.standardPercentageShare,
+    );
   });
 
   return (

--- a/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails.tsx
+++ b/components/profile/shared/lists/agreementList/multipleCauseAreasDetails/AgreementMultipleCauseAreasDetails.tsx
@@ -75,8 +75,9 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
           </div>
           <div className={style.valuesAmountContainer}>
             <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
-              {formatSum(distributionAmount.toString())} kr
+              {formatSum(distributionAmount.toString())}
             </output>
+            <span>kr</span>
           </div>
           <div className={style.valuesTaxUnitSelectorContainer}>
             <TaxUnitSelector
@@ -98,24 +99,26 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
               <div key={`dist-${causeArea.id}`}>
                 <div className={style.distributionCauseAreaInputHeader}>
                   <span>{causeArea.name}</span>
-                  {causeAreaHasMultipleOrganizations && (
-                    <div className={style.valuesSmartDistributionToggle}>
-                      <span>{configuration.smart_distribution_label}</span>
-                      <Toggle
-                        active={causeArea.standardSplit}
-                        onChange={(active) =>
-                          setDistribution({
-                            ...distribution,
-                            causeAreas: distribution.causeAreas.map((current) =>
-                              current.id === causeArea.id
-                                ? setCauseAreaStandardSplit(current, active)
-                                : { ...current },
-                            ),
-                          })
-                        }
-                      />
-                    </div>
-                  )}
+                  <div className={style.valuesSmartDistributionToggle}>
+                    {causeAreaHasMultipleOrganizations && (
+                      <>
+                        <span className="caption">{configuration.smart_distribution_label}</span>
+                        <Toggle
+                          active={causeArea.standardSplit}
+                          onChange={(active) =>
+                            setDistribution({
+                              ...distribution,
+                              causeAreas: distribution.causeAreas.map((current) =>
+                                current.id === causeArea.id
+                                  ? setCauseAreaStandardSplit(current, active)
+                                  : { ...current },
+                              ),
+                            })
+                          }
+                        />
+                      </>
+                    )}
+                  </div>
                 </div>
                 <div className={style.distributionCauseAreaInputPercentageShare}>
                   {causeArea.standardSplit ? (
@@ -142,9 +145,12 @@ export const AgreementMultipleCauseAreaDetails: React.FC<{
                       <span>kr</span>
                     </>
                   ) : (
-                    <output className={style.calculatedAmount} data-cy="cause-area-input">
-                      {formatSum((causeArea.amount ?? 0).toString())} kr
-                    </output>
+                    <>
+                      <output className={style.calculatedAmount} data-cy="cause-area-input">
+                        {formatSum((causeArea.amount ?? 0).toString())}
+                      </output>
+                      <span>kr</span>
+                    </>
                   )}
                 </div>
                 <AnimateHeight

--- a/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.module.scss
+++ b/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.module.scss
@@ -11,7 +11,8 @@
     align-items: center;
 
     &.valuesAmountContainer {
-      input {
+      input,
+      .calculatedAmount {
         width: 8em;
       }
 
@@ -45,7 +46,8 @@
     justify-content: flex-end;
   }
 
-  input {
+  input,
+  .calculatedAmount {
     background: var(--secondary);
     color: var(--primary);
     font-family: "ESKlarheitGrotesk";
@@ -54,6 +56,10 @@
     border-radius: 0.5rem;
     border: 1px solid var(--primary);
     padding: 0.5rem 1.2rem;
+  }
+
+  .calculatedAmount {
+    display: block;
   }
 }
 
@@ -77,7 +83,8 @@
       }
 
       &.valuesAmountContainer {
-        input {
+        input,
+        .calculatedAmount {
           width: 100%;
         }
       }

--- a/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.tsx
+++ b/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.tsx
@@ -21,6 +21,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
   setDay: (day: number) => void;
   sum: number;
   setSum: (sum: number) => void;
+  onSumChange: (sum: number) => void;
   taxUnits: TaxUnit[];
   dateSelectorConfig: DatePickerInputConfiguration;
 }> = ({
@@ -31,6 +32,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
   setDay,
   sum,
   setSum,
+  onSumChange,
   taxUnits,
   dateSelectorConfig,
 }) => {
@@ -55,7 +57,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
               <input
                 type="text"
                 value={formatSum(sum.toString())}
-                onChange={(e) => setSum(parseSum(e.currentTarget.value))}
+                onChange={(e) => onSumChange(parseSum(e.currentTarget.value))}
                 data-cy="agreement-list-amount-input"
               />
               <span>kr</span>

--- a/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.tsx
+++ b/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.tsx
@@ -11,9 +11,11 @@ import style from "./AgreementSingleCauseAreaDetails.module.scss";
 import { Distribution, TaxUnit } from "../../../../../../models";
 import { DistributionController } from "../../../DistributionCauseAreaInput/Distribution";
 import { useState } from "react";
+import { setCauseAreaStandardSplit } from "../../../distributionAmounts";
 
 export const AgreementSingleCauseAreaDetails: React.FC<{
   distribution: Distribution;
+  savedDistribution: Distribution;
   setDistribution: (dist: Distribution) => void;
   day: number;
   setDay: (day: number) => void;
@@ -23,6 +25,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
   dateSelectorConfig: DatePickerInputConfiguration;
 }> = ({
   distribution,
+  savedDistribution,
   setDistribution,
   day,
   setDay,
@@ -34,6 +37,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
   const [addTaxUnitOpen, setAddTaxUnitOpen] = useState(false);
 
   const currentTaxUnit = taxUnits.find((unit) => unit.id === distribution.taxUnitId);
+  const causeArea = distribution.causeAreas[0];
 
   return (
     <>
@@ -46,13 +50,21 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
           />
         </div>
         <div className={style.valuesAmountContainer}>
-          <input
-            type="text"
-            value={formatSum(sum.toString())}
-            onChange={(e) => setSum(parseSum(e.currentTarget.value))}
-            data-cy="agreement-list-amount-input"
-          />
-          <span>kr</span>
+          {causeArea.standardSplit ? (
+            <>
+              <input
+                type="text"
+                value={formatSum(sum.toString())}
+                onChange={(e) => setSum(parseSum(e.currentTarget.value))}
+                data-cy="agreement-list-amount-input"
+              />
+              <span>kr</span>
+            </>
+          ) : (
+            <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
+              {formatSum((causeArea.amount ?? 0).toString())} kr
+            </output>
+          )}
         </div>
         <div className={style.valuesTaxUnitSelectorContainer}>
           <TaxUnitSelector
@@ -64,13 +76,12 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
         <div className={style.valuesSmartDistributionToggle}>
           <span>Smart fordeling</span>
           <Toggle
-            active={distribution.causeAreas[0].standardSplit}
-            onChange={(active) =>
-              setDistribution({
-                ...distribution,
-                causeAreas: [{ ...distribution.causeAreas[0], standardSplit: active }],
-              })
-            }
+            active={causeArea.standardSplit}
+            onChange={(active) => {
+              const nextCauseArea = setCauseAreaStandardSplit(causeArea, active);
+              setDistribution({ ...distribution, causeAreas: [nextCauseArea] });
+              setSum(nextCauseArea.amount ?? 0);
+            }}
           />
         </div>
       </div>
@@ -83,6 +94,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
         >
           <DistributionController
             causeArea={causeArea}
+            savedCauseArea={savedDistribution.causeAreas.find((saved) => saved.id === causeArea.id)}
             onChange={(causeArea) => {
               const causeAreas = [...distribution.causeAreas];
               causeAreas[index] = causeArea;
@@ -120,5 +132,5 @@ const formatSum = (sum: string) => {
  * Strip thin seperator from sum and return a number.
  */
 const parseSum = (sum: string) => {
-  return parseFloat(sum.replace(/ /g, "")) || 0;
+  return parseInt(sum.replace(/ /g, ""), 10) || 0;
 };

--- a/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.tsx
+++ b/components/profile/shared/lists/agreementList/singleCauseAreaDetails/AgreementSingleCauseAreaDetails.tsx
@@ -61,9 +61,12 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
               <span>kr</span>
             </>
           ) : (
-            <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
-              {formatSum((causeArea.amount ?? 0).toString())} kr
-            </output>
+            <>
+              <output className={style.calculatedAmount} data-cy="agreement-list-amount-input">
+                {formatSum((causeArea.amount ?? 0).toString())}
+              </output>
+              <span>kr</span>
+            </>
           )}
         </div>
         <div className={style.valuesTaxUnitSelectorContainer}>
@@ -74,7 +77,7 @@ export const AgreementSingleCauseAreaDetails: React.FC<{
           />
         </div>
         <div className={style.valuesSmartDistributionToggle}>
-          <span>Smart fordeling</span>
+          <span className="caption">Smart fordeling</span>
           <Toggle
             active={causeArea.standardSplit}
             onChange={(active) => {

--- a/cypress/e2e/no/agreements.js
+++ b/cypress/e2e/no/agreements.js
@@ -553,10 +553,9 @@ describe("Agreements page", () => {
       .find("tbody")
       .first()
       .find("[data-cy=distribution-input]:visible")
-      .each(($input) => cy.wrap($input).clear().type("0"))
       .first()
       .clear()
-      .type("1300");
+      .type("1230");
 
     cy.get("[data-cy=generic-list-table]")
       .first()

--- a/cypress/e2e/no/agreements.js
+++ b/cypress/e2e/no/agreements.js
@@ -243,7 +243,7 @@ describe("Agreements page", () => {
       .first()
       .find("[data-cy=cause-area-input]")
       .first()
-      .should("contain.text", "110 kr");
+      .should("contain.text", "110");
   });
 
   // TODO: https://github.com/stiftelsen-effekt/main-site/issues/899
@@ -563,7 +563,7 @@ describe("Agreements page", () => {
       .find("tbody")
       .first()
       .find("[data-cy=agreement-list-amount-input]")
-      .should("contain.text", "1 300 kr");
+      .should("contain.text", "1 300");
 
     /**
      * Mock returned agreements on mutate

--- a/cypress/e2e/no/agreements.js
+++ b/cypress/e2e/no/agreements.js
@@ -552,7 +552,7 @@ describe("Agreements page", () => {
       .first()
       .find("tbody")
       .first()
-      .find("[data-cy=distribution-input]")
+      .find("[data-cy=distribution-input]:visible")
       .each(($input) => cy.wrap($input).clear().type("0"))
       .first()
       .clear()

--- a/cypress/e2e/no/agreements.js
+++ b/cypress/e2e/no/agreements.js
@@ -218,7 +218,7 @@ describe("Agreements page", () => {
       .should("contain.value", "30");
   });
 
-  it("Should show warning with distribution not summing to 100", () => {
+  it("Should calculate the cause area amount from organization amounts", () => {
     // Expand the first agreement
     cy.get("[data-cy=generic-list-table]")
       .first()
@@ -241,8 +241,9 @@ describe("Agreements page", () => {
       .first()
       .find("tbody")
       .first()
-      .find("[data-cy=distribution-warning]")
-      .should("be.visible");
+      .find("[data-cy=cause-area-input]")
+      .first()
+      .should("contain.text", "110 kr");
   });
 
   // TODO: https://github.com/stiftelsen-effekt/main-site/issues/899
@@ -537,7 +538,7 @@ describe("Agreements page", () => {
     cy.get("[data-cy=generic-list-table]").first().find("tbody").should("contain.text", "Den 13.");
   });
 
-  it("Should be possible to change the agreement sum", () => {
+  it("Should update the agreement sum from the distribution amounts", () => {
     // Expand the first agreement
     cy.get("[data-cy=generic-list-table]")
       .first()
@@ -547,14 +548,22 @@ describe("Agreements page", () => {
       .first()
       .click();
 
-    // Change the agreement amount
+    cy.get("[data-cy=generic-list-table]")
+      .first()
+      .find("tbody")
+      .first()
+      .find("[data-cy=distribution-input]")
+      .each(($input) => cy.wrap($input).clear().type("0"))
+      .first()
+      .clear()
+      .type("1300");
+
     cy.get("[data-cy=generic-list-table]")
       .first()
       .find("tbody")
       .first()
       .find("[data-cy=agreement-list-amount-input]")
-      .clear()
-      .type("1300");
+      .should("contain.text", "1 300 kr");
 
     /**
      * Mock returned agreements on mutate

--- a/models.ts
+++ b/models.ts
@@ -95,10 +95,12 @@ export type DistributionCauseArea = {
   name?: string;
   standardSplit: boolean;
   percentageShare: string;
+  amount?: number;
   organizations: {
     id: number;
     name?: string;
     percentageShare: string;
+    amount?: number;
   }[];
 };
 


### PR DESCRIPTION
Norwegian UI is mostly as-is, just with amounts instead of percentages.
- The total donation amount is auto-calculated as sum as soon as you turn off Smart Fordeling.
- The percentages should still be sent in the payload, just like on the main widget.
- @fellmirr ~I haven't actually tested pressing "Save" to see what happens to avoid messing with your production data.~ I did test it in the end, works as expected :tada: 


https://github.com/user-attachments/assets/573173ec-5ef0-4e4f-855f-0a734164f9dc

Danish UI has now cause areas shown, and just like in the donation widget you can allocate (portions of) amounts to an overarching "Smart fordeling" (called "Vores anbefaling" here), cause-specific "Smart fordeling", as well as individual orgs.

- Total amount is never editable here, it's always auto-calculated as a sum
- Cause areas and orgs that have `isActive: false` are not shown anymore, unless the agreement already has non-zero amount allocated for it - this is to make sure that people who used "secret link" to dedicate donation to "Andet" can still see it and edit it, but once it's zero, the cause area Andet will disappear. @fellmirr your "Andet" is marked as active, I guess with this change you can also benefit from hiding it behind a secret link if you want to.

https://github.com/user-attachments/assets/def7ce5e-f624-4e8a-9f1d-bea4f8c35f0e

