### PR TITLE
Improve donation widget and min side for amount-based donations

### DIFF
--- a/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
+++ b/components/profile/shared/lists/agreementList/DKAgreementDetails.tsx
@@ -26,7 +26,11 @@ import { DKTaxUnitCreateModal } from "../../TaxUnitModal/DKTaxUnitCreateModal";
 import { TaxUnitSelector } from "../../TaxUnitSelector/TaxUnitSelector";
 import { AgreementDetailsConfiguration } from "./AgreementDetails";
 import { DKAgreementMembershipLine } from "./DKAgreementMembershipLine";
-import { distributionTargetsMembershipFee, getDKMembershipDisplay } from "./dkMembershipDisplay";
+import {
+  distributionTargetsMembershipFee,
+  getDKMembershipDisplay,
+  MEMBERSHIP_ORGANIZATION_ID,
+} from "./dkMembershipDisplay";
 import { getUserId } from "../../../../../lib/user";
 import { cancelDKAgreement, updateDKAgreement } from "./_queries";
 import {
@@ -596,7 +600,11 @@ const addMissingCauseAreas = (distribution: Distribution, systemCauseAreas: Caus
   const nextDistribution = cloneDistribution(distribution) as Distribution;
   const distributionCauseAreaIds = nextDistribution.causeAreas.map((causeArea) => causeArea.id);
   const missingCauseAreas = systemCauseAreas.filter(
-    (causeArea) => !distributionCauseAreaIds.includes(causeArea.id),
+    (causeArea) =>
+      !distributionCauseAreaIds.includes(causeArea.id) &&
+      !causeArea.organizations.some(
+        (organization) => organization.id === MEMBERSHIP_ORGANIZATION_ID,
+      ),
   );
 
   missingCauseAreas.forEach((causeArea) => {

--- a/components/profile/shared/lists/agreementList/dkMembershipDisplay.ts
+++ b/components/profile/shared/lists/agreementList/dkMembershipDisplay.ts
@@ -2,8 +2,6 @@ import { DKAgreement, Distribution, TaxUnit } from "../../../../../models";
 
 export const MEMBERSHIP_ORGANIZATION_ID = 99;
 
-const MEMBERSHIP_ORGANIZATION_NAME = "Giv Effektivts medlemskab";
-
 export function distributionTargetsMembershipFee(
   distribution: Distribution | null | undefined,
 ): boolean {
@@ -12,10 +10,7 @@ export function distributionTargetsMembershipFee(
   }
 
   return distribution.causeAreas.some((causeArea) =>
-    causeArea.organizations?.some(
-      (org) =>
-        org.id === MEMBERSHIP_ORGANIZATION_ID || org.name?.trim() === MEMBERSHIP_ORGANIZATION_NAME,
-    ),
+    causeArea.organizations?.some((org) => org.id === MEMBERSHIP_ORGANIZATION_ID),
   );
 }
 

--- a/components/shared/components/Widget/components/panes/AmountPane/SmartDistributionForm.tsx
+++ b/components/shared/components/Widget/components/panes/AmountPane/SmartDistributionForm.tsx
@@ -14,11 +14,7 @@ import {
 import { MultipleCauseAreaIcon } from "../SelectionPane.style";
 import { CauseArea } from "../../../types/CauseArea";
 import { ShareType } from "../../../types/Enums";
-import {
-  setCauseAreaAmount,
-  setCauseAreaDistributionType,
-  setSmartDistributionTotal,
-} from "../../../store/donation/actions";
+import { setSmartDistributionTotal } from "../../../store/donation/actions";
 import { EffektButton, EffektButtonVariant } from "../../../../EffektButton/EffektButton";
 import { thousandize } from "../../../../../../../util/formatting";
 import { State } from "../../../store/state";
@@ -60,18 +56,6 @@ export const SmartDistributionForm: React.FC<SmartDistributionFormProps> = ({
   const handleSuggestedSumClick = (suggestedAmount: number) => {
     plausible("SelectSuggestedSum", { props: { sum: suggestedAmount } });
     dispatch(setSmartDistributionTotal(suggestedAmount));
-
-    causeAreas.forEach((ca) => {
-      if (ca.standardPercentageShare && ca.standardPercentageShare > 0) {
-        dispatch(
-          setCauseAreaAmount(
-            ca.id,
-            Math.round((ca.standardPercentageShare / 100) * suggestedAmount),
-          ),
-        );
-        dispatch(setCauseAreaDistributionType(ca.id, ShareType.STANDARD));
-      }
-    });
   };
 
   const handleTotalAmountChange = (
@@ -87,27 +71,6 @@ export const SmartDistributionForm: React.FC<SmartDistributionFormProps> = ({
     if (sourceInfo.source !== "event") return;
     const v = values.floatValue === undefined ? 0 : values.floatValue;
     dispatch(setSmartDistributionTotal(v));
-
-    if (v > 0) {
-      let sumForTipCalculation = 0;
-      causeAreas.forEach((ca) => {
-        if (ca.standardPercentageShare && ca.standardPercentageShare > 0) {
-          const amountForCA = Math.round((ca.standardPercentageShare / 100) * v);
-          dispatch(setCauseAreaAmount(ca.id, amountForCA));
-          dispatch(setCauseAreaDistributionType(ca.id, ShareType.STANDARD));
-          if (ca.id !== 4) {
-            sumForTipCalculation += amountForCA;
-          }
-        }
-      });
-    } else {
-      causeAreas.forEach((ca) => {
-        if (ca.standardPercentageShare && ca.standardPercentageShare > 0) {
-          dispatch(setCauseAreaAmount(ca.id, 0));
-          dispatch(setCauseAreaDistributionType(ca.id, ShareType.STANDARD));
-        }
-      });
-    }
   };
 
   return (

--- a/components/shared/components/Widget/components/panes/AmountPane/index.tsx
+++ b/components/shared/components/Widget/components/panes/AmountPane/index.tsx
@@ -125,6 +125,15 @@ export const AmountPane: React.FC<AmountPaneProps> = ({
             {/* For multiple cause areas */}
             {selectionType === "multiple" && selectedCauseAreaId !== -1 && (
               <>
+                <SmartDistributionForm
+                  suggestedSums={suggestedSums}
+                  totalAmount={totalAmount}
+                  causeAreas={causeAreas}
+                  causeAreaAmounts={causeAreaAmounts}
+                  causeAreaDistributionType={causeAreaDistributionType}
+                  smartDistributionContext={smartDistContext}
+                  causeAreaDisplayConfig={causeAreaDisplayConfig}
+                />
                 {causeAreas
                   .filter((ca) => ca.isActive || prefilledCauseAreaIds.has(ca.id))
                   .filter(
@@ -186,15 +195,18 @@ export const AmountPane: React.FC<AmountPaneProps> = ({
             )}
 
             {selectedCauseAreaId === -1 && (
-              <SmartDistributionForm
-                suggestedSums={suggestedSums}
-                totalAmount={totalAmount}
-                causeAreas={causeAreas}
-                causeAreaAmounts={causeAreaAmounts}
-                causeAreaDistributionType={causeAreaDistributionType}
-                smartDistributionContext={smartDistContext}
-                causeAreaDisplayConfig={causeAreaDisplayConfig}
-              />
+              <>
+                <SmartDistributionForm
+                  suggestedSums={suggestedSums}
+                  totalAmount={totalAmount}
+                  causeAreas={causeAreas}
+                  causeAreaAmounts={causeAreaAmounts}
+                  causeAreaDistributionType={causeAreaDistributionType}
+                  smartDistributionContext={smartDistContext}
+                  causeAreaDisplayConfig={causeAreaDisplayConfig}
+                />
+                <GlobalCutToggle operationsConfig={operationsConfig} />
+              </>
             )}
           </CauseAreasWrapper>
         </div>

--- a/components/shared/components/Widget/components/panes/AmountPane/useAmountCalculation.ts
+++ b/components/shared/components/Widget/components/panes/AmountPane/useAmountCalculation.ts
@@ -16,6 +16,7 @@ export const useAmountCalculation = (
     operationsPercentageByCauseArea = {},
     globalOperationsEnabled = false,
     operationsConfig,
+    smartDistributionTotal = 0,
   } = useSelector((state: State) => state.donation);
 
   const OPERATIONS_CAUSE_AREA_ID = operationsConfig?.operationsCauseAreaId;
@@ -87,6 +88,8 @@ export const useAmountCalculation = (
           return acc + (causeAreaAmounts[area.id] || 0);
         }, 0);
 
+      currentTotal += smartDistributionTotal;
+
       // For multiple cause areas, the total is just the sum of amounts entered
       // Operations cut is calculated FROM this total, not added to it
     } else if (selectionType === "single" && selectedCauseAreaId != null) {
@@ -115,6 +118,7 @@ export const useAmountCalculation = (
     causeAreaDistributionType,
     globalOperationsEnabled,
     OPERATIONS_CAUSE_AREA_ID,
+    smartDistributionTotal,
   ]);
 
   return {

--- a/components/shared/components/Widget/components/shared/DonationSummary/DonationSummary.tsx
+++ b/components/shared/components/Widget/components/shared/DonationSummary/DonationSummary.tsx
@@ -177,9 +177,7 @@ export const DonationSummary: React.FC<{ text: DonationSummaryText }> = ({ text 
                   }
                 >
                   {(!item.orgs || item.orgs.length === 0) &&
-                    `${item.amount !== Math.round(item.amount) ? "~" : ""} ${Math.round(
-                      item.amount,
-                    ).toLocaleString("no-NB")} kr`}
+                    `${item.amount.toLocaleString("no-NB")} kr`}
                 </td>
               </tr>
               {item.orgs &&
@@ -189,8 +187,7 @@ export const DonationSummary: React.FC<{ text: DonationSummaryText }> = ({ text 
                       {org.name}
                     </td>
                     <td data-cy={`summary-org-${org.id}-amount`}>
-                      {org.amount !== Math.round(org.amount) ? "~" : null}{" "}
-                      {Math.round(org.amount).toLocaleString("no-NB")} kr
+                      {org.amount.toLocaleString("no-NB")} kr
                     </td>
                   </tr>
                 ))}

--- a/components/shared/components/Widget/components/shared/DonationSummary/DonationSummary.tsx
+++ b/components/shared/components/Widget/components/shared/DonationSummary/DonationSummary.tsx
@@ -47,12 +47,23 @@ export const DonationSummary: React.FC<{ text: DonationSummaryText }> = ({ text 
 
     // Special handling for smart distribution mode
     if (selectedCauseAreaId === -1 && smartDistributionTotal > 0) {
+      const operationsAmount = globalOperationsEnabled
+        ? Math.round((smartDistributionTotal * globalOperationsPercentage) / 100)
+        : 0;
       summaryItems.push({
         id: -1,
         name: text.smart_distribution_title,
-        amount: smartDistributionTotal,
+        amount: smartDistributionTotal - operationsAmount,
         orgs: [],
       });
+      if (operationsAmount > 0 && operationsConfig?.operationsCauseAreaId !== undefined) {
+        summaryItems.push({
+          id: operationsConfig.operationsCauseAreaId,
+          name: text.operations_summary_label,
+          amount: operationsAmount,
+          orgs: [],
+        });
+      }
       return { summaryItems, sum: smartDistributionTotal };
     }
 
@@ -126,6 +137,7 @@ export const DonationSummary: React.FC<{ text: DonationSummaryText }> = ({ text 
     globalOperationsEnabled,
     smartDistributionTotal,
     globalOperationsPercentage,
+    operationsConfig,
     text.smart_distribution_title,
     text.operations_summary_label,
   ]);

--- a/components/shared/components/Widget/store/donation/saga.ts
+++ b/components/shared/components/Widget/store/donation/saga.ts
@@ -244,7 +244,14 @@ export function* registerDonation(
     // Build the distribution payload from the breakdown
     allCauseAreas.forEach((area) => {
       const orgAmountsForArea = area.organizations
-        .map((org) => ({ id: org.id, amount: breakdown.organizationAmounts[org.id] || 0 }))
+        .map((org) => ({
+          id: org.id,
+          amount:
+            (breakdown.organizationAmounts[org.id] || 0) +
+            (area.id === OPERATIONS_CAUSE_AREA_ID && org.standardShare
+              ? (org.standardShare / 100) * breakdown.operationsAmount
+              : 0),
+        }))
         .filter((org) => org.amount > 0);
 
       // Only add areas that have organizations with amounts

--- a/components/shared/components/Widget/utils/donationCalculations.test.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.test.ts
@@ -1,7 +1,76 @@
 import {
+  calculateDonationBreakdown,
   calculateOrganizationSharesWithinCauseArea,
   distributeSharesWithRemainder,
 } from "./donationCalculations";
+
+describe("calculateDonationBreakdown", () => {
+  const causeAreas = [
+    {
+      id: 1,
+      name: "Area 1",
+      standardPercentageShare: 60,
+      organizations: [{ id: 11, standardShare: 100 }],
+    },
+    {
+      id: 2,
+      name: "Area 2",
+      standardPercentageShare: 40,
+      organizations: [{ id: 22, standardShare: 100 }],
+    },
+    {
+      id: 4,
+      name: "Operations",
+      standardPercentageShare: 0,
+      organizations: [{ id: 44, standardShare: 100 }],
+    },
+  ] as any;
+
+  it("applies an operations percentage to smart distribution", () => {
+    const breakdown = calculateDonationBreakdown(
+      {},
+      {},
+      {},
+      {},
+      {},
+      causeAreas,
+      "multiple",
+      -1,
+      true,
+      5,
+      [],
+      4,
+      1000,
+    );
+
+    expect(breakdown.totalAmount).toBe(1000);
+    expect(breakdown.operationsAmount).toBe(50);
+    expect(breakdown.causeAreaAmounts).toEqual({ 1: 570, 2: 380 });
+  });
+
+  it("combines smart distribution, specific areas, and operations", () => {
+    const breakdown = calculateDonationBreakdown(
+      { 1: 500 },
+      {},
+      { 1: 1, 2: 1, 4: 1 } as any,
+      {},
+      {},
+      causeAreas,
+      "multiple",
+      undefined,
+      true,
+      5,
+      [],
+      4,
+      500,
+    );
+
+    expect(breakdown.totalAmount).toBe(1000);
+    expect(breakdown.operationsAmount).toBe(50);
+    expect(breakdown.causeAreaAmounts[1]).toBe(760);
+    expect(breakdown.causeAreaAmounts[2]).toBe(190);
+  });
+});
 
 describe("distributeSharesWithRemainder", () => {
   const sumOfShares = (shares: { percentageShare: string }[]) =>

--- a/components/shared/components/Widget/utils/donationCalculations.test.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.test.ts
@@ -70,6 +70,38 @@ describe("calculateDonationBreakdown", () => {
     expect(breakdown.causeAreaAmounts[1]).toBe(760);
     expect(breakdown.causeAreaAmounts[2]).toBe(190);
   });
+
+  it("uses operations as the integer remainder after rounding custom donations", () => {
+    const customCauseAreas = [
+      { id: 1, name: "Area 1", organizations: [{ id: 11, standardShare: 100 }] },
+      { id: 2, name: "Area 2", organizations: [{ id: 22, standardShare: 100 }] },
+      { id: 3, name: "Area 3", organizations: [{ id: 33, standardShare: 100 }] },
+      causeAreas[2],
+    ] as any;
+    const breakdown = calculateDonationBreakdown(
+      {},
+      { 11: 10, 22: 20, 33: 30 },
+      { 1: 0, 2: 0, 3: 0, 4: 1 } as any,
+      {},
+      {},
+      customCauseAreas,
+      "multiple",
+      undefined,
+      true,
+      5,
+      [],
+      4,
+    );
+
+    expect(breakdown.causeAreaAmounts).toEqual({ 1: 10, 2: 19, 3: 29 });
+    expect(breakdown.organizationAmounts).toEqual({ 11: 10, 22: 19, 33: 29 });
+    expect(breakdown.operationsAmount).toBe(2);
+    expect(breakdown.totalAmount).toBe(60);
+    expect(
+      Object.values(breakdown.causeAreaAmounts).reduce((sum, amount) => sum + amount, 0) +
+        breakdown.operationsAmount,
+    ).toBe(breakdown.totalAmount);
+  });
 });
 
 describe("distributeSharesWithRemainder", () => {
@@ -142,7 +174,7 @@ describe("calculateOrganizationSharesWithinCauseArea", () => {
       { id: 2, amount: 75 },
     ]);
 
-    expect(shares.find((s) => s.id === 1)?.percentageShare).toBe("25.00000000");
+    expect(shares.find((s) => s.id === 1)?.percentageShare).toBe("25");
     // Org 2 has the largest amount, so it absorbs the rounding remainder
     // (100 - sum of the others) rather than being independently rounded
     expect(shares.find((s) => s.id === 2)?.percentageShare).toBe("75");
@@ -190,7 +222,9 @@ describe("calculateOrganizationSharesWithinCauseArea", () => {
       { id: 2, amount: 74.6 },
     ]);
     expect(shares.find((s) => s.id === 1)?.amount).toBe(25);
+    expect(shares.find((s) => s.id === 1)?.percentageShare).toBe("25");
     expect(shares.find((s) => s.id === 2)?.amount).toBe(75);
+    expect(shares.find((s) => s.id === 2)?.percentageShare).toBe("75");
   });
 
   it("returns an empty array when there are no positive amounts", () => {

--- a/components/shared/components/Widget/utils/donationCalculations.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.ts
@@ -38,12 +38,16 @@ export function calculateDonationBreakdown(
 
   // Handle smart distribution mode
   if (selectedCauseAreaId === -1 && smartDistributionTotal) {
+    const operationsAmount = globalOperationsEnabled
+      ? Math.round((smartDistributionTotal * globalOperationsPercentage) / 100)
+      : 0;
+    const distributedAmount = smartDistributionTotal - operationsAmount;
+
     causeAreas.forEach((area) => {
       if (area.standardPercentageShare && area.standardPercentageShare > 0) {
-        const areaAmount = (area.standardPercentageShare / 100) * smartDistributionTotal;
+        const areaAmount = (area.standardPercentageShare / 100) * distributedAmount;
         result.causeAreaAmounts[area.id] = areaAmount;
 
-        // Distribute among organizations
         area.organizations.forEach((org) => {
           if (org.standardShare && org.standardShare > 0) {
             const orgAmount = (org.standardShare / 100) * areaAmount;
@@ -52,6 +56,7 @@ export function calculateDonationBreakdown(
         });
       }
     });
+    result.operationsAmount = operationsAmount;
     result.totalAmount = smartDistributionTotal;
     return result;
   }
@@ -65,15 +70,17 @@ export function calculateDonationBreakdown(
       .filter((area) => causeAreaDistributionType[area.id] === ShareType.CUSTOM)
       .map((area) => area.id);
     // For multiple cause areas, calculate based on global percentage
-    multipleTotalDonation = Object.entries(causeAreaAmounts).reduce(
-      (sum, entry) =>
-        sum +
-        (ignoredCauseAreas.includes(parseInt(entry[0])) ||
-        customDistributionAreasIds.includes(parseInt(entry[0]))
-          ? 0
-          : entry[1]),
-      0,
-    );
+    multipleTotalDonation =
+      (smartDistributionTotal || 0) +
+      Object.entries(causeAreaAmounts).reduce(
+        (sum, entry) =>
+          sum +
+          (ignoredCauseAreas.includes(parseInt(entry[0])) ||
+          customDistributionAreasIds.includes(parseInt(entry[0]))
+            ? 0
+            : entry[1]),
+        0,
+      );
     // Add organization amounts for custom distribution
     for (const customCauseAreaId of customDistributionAreasIds) {
       const orgs = causeAreas.find((area) => area.id === customCauseAreaId)?.organizations || [];
@@ -103,6 +110,26 @@ export function calculateDonationBreakdown(
   }
 
   result.operationsAmount = totalOperationsAmount;
+
+  if (selectionType === "multiple" && smartDistributionTotal && smartDistributionTotal > 0) {
+    const reduction =
+      multipleTotalDonation > 0 ? 1 - totalOperationsAmount / multipleTotalDonation : 1;
+    const netSmartDistributionAmount = smartDistributionTotal * reduction;
+
+    causeAreas.forEach((area) => {
+      if (area.standardPercentageShare && area.standardPercentageShare > 0) {
+        const areaAmount = (area.standardPercentageShare / 100) * netSmartDistributionAmount;
+        result.causeAreaAmounts[area.id] = (result.causeAreaAmounts[area.id] || 0) + areaAmount;
+
+        area.organizations.forEach((org) => {
+          if (org.standardShare && org.standardShare > 0) {
+            result.organizationAmounts[org.id] =
+              (result.organizationAmounts[org.id] || 0) + (org.standardShare / 100) * areaAmount;
+          }
+        });
+      }
+    });
+  }
 
   // Process each cause area
   causeAreas.forEach((area) => {
@@ -143,7 +170,7 @@ export function calculateDonationBreakdown(
         netAreaAmount = areaAmount - operationsCut;
       }
 
-      result.causeAreaAmounts[area.id] = netAreaAmount;
+      result.causeAreaAmounts[area.id] = (result.causeAreaAmounts[area.id] || 0) + netAreaAmount;
 
       // Distribute to organizations based on standard shares
       area.organizations.forEach((org) => {
@@ -186,7 +213,8 @@ export function calculateDonationBreakdown(
           }
         }
 
-        result.causeAreaAmounts[area.id] = netTotalOrgAmount;
+        result.causeAreaAmounts[area.id] =
+          (result.causeAreaAmounts[area.id] || 0) + netTotalOrgAmount;
 
         // Apply reduction to each organization
         area.organizations.forEach((org) => {

--- a/components/shared/components/Widget/utils/donationCalculations.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.ts
@@ -229,12 +229,105 @@ export function calculateDonationBreakdown(
     }
   });
 
-  // Calculate total
-  result.totalAmount =
+  const totalAmount = Math.round(
     Object.values(result.causeAreaAmounts).reduce((sum, amount) => sum + amount, 0) +
-    result.operationsAmount;
+      result.operationsAmount,
+  );
+  const hasOperationsCut =
+    (selectionType === "multiple" && globalOperationsEnabled) ||
+    (selectionType === "single" &&
+      selectedCauseAreaId !== null &&
+      selectedCauseAreaId !== undefined &&
+      operationsPercentageModeByCauseArea[selectedCauseAreaId]);
+  const exactCauseAreaAmounts = { ...result.causeAreaAmounts };
+  const roundedCauseAreaAmounts: Record<number, number> = {};
+
+  Object.entries(exactCauseAreaAmounts).forEach(([id, amount]) => {
+    const areaId = Number(id);
+    const area = causeAreas.find((candidate) => candidate.id === areaId);
+    const isCustom = causeAreaDistributionType[areaId] === ShareType.CUSTOM;
+    roundedCauseAreaAmounts[areaId] = isCustom
+      ? (area?.organizations || []).reduce(
+          (sum, org) => sum + Math.round(result.organizationAmounts[org.id] || 0),
+          0,
+        )
+      : Math.round(amount);
+  });
+
+  let roundedDistributedAmount = Object.values(roundedCauseAreaAmounts).reduce(
+    (sum, amount) => sum + amount,
+    0,
+  );
+  const largestCauseAreaId = Object.keys(roundedCauseAreaAmounts)
+    .map(Number)
+    .sort(
+      (left, right) =>
+        roundedCauseAreaAmounts[right] - roundedCauseAreaAmounts[left] || left - right,
+    )[0];
+
+  if (largestCauseAreaId !== undefined) {
+    if (roundedDistributedAmount > totalAmount) {
+      roundedCauseAreaAmounts[largestCauseAreaId] -= roundedDistributedAmount - totalAmount;
+      roundedDistributedAmount = totalAmount;
+    } else if (!hasOperationsCut && roundedDistributedAmount < totalAmount) {
+      roundedCauseAreaAmounts[largestCauseAreaId] += totalAmount - roundedDistributedAmount;
+      roundedDistributedAmount = totalAmount;
+    }
+  }
+
+  result.causeAreaAmounts = roundedCauseAreaAmounts;
+  result.operationsAmount = hasOperationsCut ? totalAmount - roundedDistributedAmount : 0;
+  result.totalAmount = totalAmount;
+
+  causeAreas.forEach((area) => {
+    const areaAmount = result.causeAreaAmounts[area.id];
+    if (areaAmount === undefined) return;
+
+    const exactOrganizationAmounts = area.organizations
+      .map((org) => ({ id: org.id, amount: result.organizationAmounts[org.id] || 0 }))
+      .filter((org) => org.amount > 0);
+    const roundedOrganizationAmounts = roundAmountsToTotal(exactOrganizationAmounts, areaAmount);
+
+    area.organizations.forEach((org) => {
+      delete result.organizationAmounts[org.id];
+    });
+    roundedOrganizationAmounts.forEach(({ id, amount }) => {
+      result.organizationAmounts[id] = amount;
+    });
+  });
 
   return result;
+}
+
+function roundAmountsToTotal<T extends { id: number; amount: number }>(
+  amounts: T[],
+  targetTotal: number,
+): T[] {
+  if (amounts.length === 0 || targetTotal <= 0) return [];
+
+  const rounded = amounts.map((item) => ({ ...item, amount: Math.floor(item.amount) }));
+  let remainder = targetTotal - rounded.reduce((sum, item) => sum + item.amount, 0);
+  const incrementOrder = amounts
+    .map((item, index) => ({ index, fraction: item.amount - Math.floor(item.amount), id: item.id }))
+    .sort((left, right) => right.fraction - left.fraction || left.id - right.id);
+
+  for (let index = 0; remainder > 0; index++, remainder--) {
+    rounded[incrementOrder[index % incrementOrder.length].index].amount += 1;
+  }
+
+  const decrementOrder = rounded
+    .map((item, index) => ({ index, amount: item.amount, id: item.id }))
+    .sort((left, right) => right.amount - left.amount || left.id - right.id);
+
+  for (let index = 0; remainder < 0; index++) {
+    const item = rounded[decrementOrder[index % decrementOrder.length].index];
+    if (item.amount > 0) {
+      item.amount -= 1;
+      remainder += 1;
+    }
+  }
+
+  return rounded.filter((item) => item.amount > 0);
 }
 
 export interface OrganizationSharePayload {
@@ -269,7 +362,7 @@ export function distributeSharesWithRemainder<T extends { id: number; amount: nu
 
   const otherShares = others.map((item) => ({
     ...item,
-    percentageShare: ((item.amount / total) * 100).toFixed(8),
+    percentageShare: parseFloat(((item.amount / total) * 100).toFixed(8)).toString(),
   }));
 
   const sumOfOthers = otherShares.reduce(
@@ -287,9 +380,14 @@ export function distributeSharesWithRemainder<T extends { id: number; amount: nu
 export function calculateOrganizationSharesWithinCauseArea(
   organizationAmounts: { id: number; amount: number }[],
 ): OrganizationSharePayload[] {
-  return distributeSharesWithRemainder(organizationAmounts).map((share) => ({
+  const totalAmount = Math.round(
+    organizationAmounts.reduce((sum, organization) => sum + organization.amount, 0),
+  );
+  const roundedAmounts = roundAmountsToTotal(organizationAmounts, totalAmount);
+
+  return distributeSharesWithRemainder(roundedAmounts).map((share) => ({
     id: share.id,
     percentageShare: share.percentageShare,
-    amount: Math.round(share.amount),
+    amount: share.amount,
   }));
 }

--- a/cypress/e2e/no/organizations.js
+++ b/cypress/e2e/no/organizations.js
@@ -214,7 +214,7 @@ describe("Organizations Page", () => {
       expect(causeArea.id).to.eq(1);
       expect(causeArea.standardSplit).to.eq(false);
       expect(causeArea.organizations).to.deep.equal([
-        { id: 12, percentageShare: "40.00000000", amount: 400 },
+        { id: 12, percentageShare: "40", amount: 400 },
         { id: 1, percentageShare: "60", amount: 600 },
       ]);
 

--- a/cypress/e2e/no/widget-multiple-cause-areas.js
+++ b/cypress/e2e/no/widget-multiple-cause-areas.js
@@ -5,17 +5,15 @@
 // This spec forces a multi-cause-area fixture so that flow keeps working too.
 describe("Widget multiple cause areas", () => {
   beforeEach(() => {
-    cy.fixture("cause_areas_multiple")
-      .then((causeAreas) => {
-        cy.intercept("GET", "/causeareas/all", {
-          statusCode: 200,
-          body: {
-            status: 200,
-            content: causeAreas,
-          },
-        });
-      })
-      .as("getCauseAreas");
+    cy.fixture("cause_areas_multiple").then((causeAreas) => {
+      cy.intercept("GET", "/causeareas/all", {
+        statusCode: 200,
+        body: {
+          status: 200,
+          content: causeAreas,
+        },
+      }).as("getCauseAreas");
+    });
 
     cy.fixture("referrals").then((referrals) => {
       cy.intercept("GET", "/referrals/types", {
@@ -33,8 +31,9 @@ describe("Widget multiple cause areas", () => {
         "x-vercel-skip-toolbar": "1",
       },
     });
-    cy.wait(500);
-    cy.get("[data-cy=gi-button]").click();
+    cy.wait("@getCauseAreas");
+    cy.get("[data-cy=gi-button]").should("be.visible").click();
+    cy.get("[data-cy=widget-pane]").should("be.visible");
   });
 
   it("Shows the cause area selection pane instead of SingleCauseAreaPane", () => {

--- a/cypress/e2e/no/widget.js
+++ b/cypress/e2e/no/widget.js
@@ -2,17 +2,15 @@ import mockDonor from "../../fixtures/no/donor.json";
 
 describe("Widget", () => {
   beforeEach(() => {
-    cy.fixture("cause_areas")
-      .then((causeAreas) => {
-        cy.intercept("GET", "/causeareas/all", {
-          statusCode: 200,
-          body: {
-            status: 200,
-            content: causeAreas,
-          },
-        });
-      })
-      .as("getCauseAreas");
+    cy.fixture("cause_areas").then((causeAreas) => {
+      cy.intercept("GET", "/causeareas/all", {
+        statusCode: 200,
+        body: {
+          status: 200,
+          content: causeAreas,
+        },
+      }).as("getCauseAreas");
+    });
 
     cy.fixture("referrals").then((referrals) => {
       cy.intercept("GET", "/referrals/types", {
@@ -30,8 +28,9 @@ describe("Widget", () => {
         "x-vercel-skip-toolbar": "1",
       },
     });
-    cy.wait(500);
-    cy.get("[data-cy=gi-button]").click();
+    cy.wait("@getCauseAreas");
+    cy.get("[data-cy=gi-button]").should("be.visible").click();
+    cy.get("[data-cy=widget-pane]").should("be.visible");
   });
 
   it("End-2-End single bank donation", () => {

--- a/cypress/e2e/se/widget-cause-area-selection.js
+++ b/cypress/e2e/se/widget-cause-area-selection.js
@@ -76,13 +76,16 @@ describe("Swedish Widget - Cause Area Selection", () => {
     cy.get("[data-cy=summary-smart-distribution]").should("exist");
     cy.get("[data-cy=summary-smart-distribution-name]").should("contain.text", "Smart fördelning");
     cy.get("[data-cy=summary-smart-distribution-amount]").should(($el) => {
-      const text = $el.text().replace(/\s/g, ""); // Remove all whitespace
-      expect(text).to.match(/1000kr/i); // Should contain 1000kr (case insensitive)
+      const text = $el.text().replace(/\s/g, "");
+      expect(text).to.match(/900kr/i);
     });
 
-    // Individual cause areas should NOT appear in summary for smart distribution
     cy.get("[data-cy=summary-cause-area-1-name]").should("not.exist");
-    cy.get("[data-cy=summary-cause-area-4-name]").should("not.exist");
+    cy.get("[data-cy=summary-cause-area-4-name]").should("exist");
+    cy.get("[data-cy=summary-cause-area-4-amount]").should(($el) => {
+      const text = $el.text().replace(/\s/g, "");
+      expect(text).to.match(/100kr/i);
+    });
     cy.get("[data-cy=summary-cause-area-2-amount]").should("not.exist");
     cy.get("[data-cy=summary-cause-area-3-amount]").should("not.exist");
 
@@ -144,12 +147,14 @@ describe("Swedish Widget - Cause Area Selection", () => {
     cy.get("[data-cy=donation-summary]").should("exist");
     cy.get("[data-cy=summary-smart-distribution]").should("exist");
     cy.get("[data-cy=summary-smart-distribution-amount]").should(($el) => {
-      const text = $el.text().replace(/\s/g, ""); // Remove all whitespace
-      expect(text).to.match(/500kr/i); // Should contain 500kr (case insensitive)
+      const text = $el.text().replace(/\s/g, "");
+      expect(text).to.match(/450kr/i);
     });
 
-    // Individual cause areas should NOT appear in summary for smart distribution
     cy.get("[data-cy=summary-cause-area-1-amount]").should("not.exist");
-    cy.get("[data-cy=summary-cause-area-4-amount]").should("not.exist");
+    cy.get("[data-cy=summary-cause-area-4-amount]").should(($el) => {
+      const text = $el.text().replace(/\s/g, "");
+      expect(text).to.match(/50kr/i);
+    });
   });
 });

--- a/cypress/e2e/se/widget-registration-smart-distribution.js
+++ b/cypress/e2e/se/widget-registration-smart-distribution.js
@@ -43,17 +43,15 @@ describe("Swedish Widget - Smart Distribution Registration", () => {
 
       expect(body.amount).to.equal(1000);
 
-      // Based on fixture: Global hälsa has 90% standardPercentageShare, Operations has 10%
-      // So 900 kr should go to Global hälsa, 100 kr to Operations
       expect(body.distributionCauseAreas).to.have.length(2);
 
       const globalHealth = body.distributionCauseAreas.find((ca) => ca.id === 1);
       expect(globalHealth).to.exist;
-      expect(parseFloat(globalHealth.percentageShare)).to.equal(90);
+      expect(parseFloat(globalHealth.percentageShare)).to.equal(81);
 
       const operations = body.distributionCauseAreas.find((ca) => ca.id === 4);
       expect(operations).to.exist;
-      expect(parseFloat(operations.percentageShare)).to.equal(10);
+      expect(parseFloat(operations.percentageShare)).to.equal(19);
     });
   });
 
@@ -76,21 +74,19 @@ describe("Swedish Widget - Smart Distribution Registration", () => {
 
       expect(body.amount).to.equal(500);
 
-      // Since smart distribution uses standardPercentageShare from fixture
-      // Global hälsa has 90%, Operations has 10% - this replaces manual tip functionality
       expect(body.distributionCauseAreas).to.have.length(2);
 
       const globalHealth = body.distributionCauseAreas.find((ca) => ca.id === 1);
       expect(globalHealth).to.exist;
-      expect(parseFloat(globalHealth.percentageShare)).to.equal(90);
+      expect(parseFloat(globalHealth.percentageShare)).to.equal(81);
 
       const operations = body.distributionCauseAreas.find((ca) => ca.id === 4);
       expect(operations).to.exist;
-      expect(parseFloat(operations.percentageShare)).to.equal(10);
+      expect(parseFloat(operations.percentageShare)).to.equal(19);
     });
   });
 
-  it("Should not show operations amounts in UI summary when switching to smart distribution", () => {
+  it("Should show only the current operations amount when switching to smart distribution", () => {
     // Start with single cause area and enable tip
     cy.get("[data-cy=cause-area-1]").click();
     setCauseAreaAmount(1, 100, true); // 100 kr with 10% tip = 90 kr + 10 kr operations
@@ -107,22 +103,20 @@ describe("Swedish Widget - Smart Distribution Registration", () => {
     // Check that the donation summary UI shows smart distribution, not leaked operations
     cy.get("[data-cy=donation-summary]").should("exist");
 
-    // Operations cause area should not exist at all in smart distribution
-    cy.get("[data-cy=summary-cause-area-4]").should("not.exist");
-
-    // Should show smart distribution as a single entry, not breakdown
     cy.get("[data-cy=summary-smart-distribution]").should("exist");
     cy.get("[data-cy=summary-smart-distribution-amount]").should(($el) => {
-      const text = $el.text().replace(/\s/g, ""); // Remove all whitespace
-      expect(text).to.match(/500kr/i); // Should contain 500kr (case insensitive)
+      const text = $el.text().replace(/\s/g, "");
+      expect(text).to.match(/450kr/i);
     });
 
-    // Should NOT show individual cause area breakdowns in summary for smart distribution
     cy.get("[data-cy=summary-cause-area-1-amount]").should("not.exist");
-    cy.get("[data-cy=summary-cause-area-4-amount]").should("not.exist");
+    cy.get("[data-cy=summary-cause-area-4-amount]").should(($el) => {
+      const text = $el.text().replace(/\s/g, "");
+      expect(text).to.match(/50kr/i);
+    });
   });
 
-  it("Should not show operations amounts from single cause area when switching to smart distribution", () => {
+  it("Should not retain operations amounts from a previous selection", () => {
     // Start with single cause area and enable tip
     cy.get("[data-cy=cause-area-1]").click();
     setCauseAreaAmount(1, 500, true); // 500 kr with 10% tip = 450 kr + 50 kr operations
@@ -141,22 +135,19 @@ describe("Swedish Widget - Smart Distribution Registration", () => {
     // Submit to check the registration request
     cy.get("[data-cy^=payment-method-]").first().click();
 
-    // Verify the registration request - should only have smart distribution (90%/10%)
     cy.wait("@registerDonation").then((interception) => {
       const { body } = interception.request;
 
       expect(body.amount).to.equal(1000);
       expect(body.distributionCauseAreas).to.have.length(2);
 
-      // Should be 900 kr to Global hälsa (90%) and 100 kr to Operations (10%)
-      // NOT 475 kr to Global hälsa + 25 kr leftover operations + smart distribution operations
       const globalHealth = body.distributionCauseAreas.find((ca) => ca.id === 1);
       expect(globalHealth).to.exist;
-      expect(parseFloat(globalHealth.percentageShare)).to.equal(90);
+      expect(parseFloat(globalHealth.percentageShare)).to.equal(81);
 
       const operations = body.distributionCauseAreas.find((ca) => ca.id === 4);
       expect(operations).to.exist;
-      expect(parseFloat(operations.percentageShare)).to.equal(10);
+      expect(parseFloat(operations.percentageShare)).to.equal(19);
 
       // Total should be exactly 100%
       const totalPercentage = body.distributionCauseAreas.reduce(


### PR DESCRIPTION
1. Min side: Improve handling of DK memberships
2. Donation widget:
    a. Allow %-til-drift for global "Smart fordeling"

    https://github.com/user-attachments/assets/ec5fbf57-e4af-4b0c-8c86-453b8c157911

    b. Show global "Smart fordeling" in multiple causes, allowing donors to express the intent of e.g. dedicating a portion to a certain cause area and entrusting us to allocate the rest of the money wherever it makes most impact across all cause areas.

    https://github.com/user-attachments/assets/992e2a25-ff25-4836-8c5f-c4ebd9a99908

    c. No more approximate amounts - when `%-til drift` is enabled, we first calculate the new amount for all selected charitable contributions, and then calculate the amount for "drift" as the difference between full donation amount and all those charitable amounts.

    https://github.com/user-attachments/assets/76be3507-8420-4de5-aa95-5379442e43ff

