### PR TITLE
improve split of donation for ops on small amounts

### DIFF
--- a/components/shared/components/Widget/utils/donationCalculations.test.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.test.ts
@@ -114,7 +114,29 @@ describe("calculateDonationBreakdown", () => {
     expect(breakdown.causeAreaAmounts[4]).toBeUndefined();
   });
 
-  it("uses operations as the integer remainder after rounding custom donations", () => {
+  it("preserves a one-krone operations cut when cause area amounts round up", () => {
+    const breakdown = calculateDonationBreakdown(
+      { 1: 10, 2: 10 },
+      {},
+      { 1: 1, 2: 1, 4: 1 } as any,
+      {},
+      {},
+      causeAreas,
+      "multiple",
+      undefined,
+      true,
+      5,
+      [],
+      4,
+    );
+
+    expect(breakdown.causeAreaAmounts).toEqual({ 1: 10, 2: 9 });
+    expect(breakdown.organizationAmounts).toEqual({ 11: 10, 22: 9 });
+    expect(breakdown.operationsAmount).toBe(1);
+    expect(breakdown.totalAmount).toBe(20);
+  });
+
+  it("keeps the configured operations amount after rounding custom donations", () => {
     const customCauseAreas = [
       { id: 1, name: "Area 1", organizations: [{ id: 11, standardShare: 100 }] },
       { id: 2, name: "Area 2", organizations: [{ id: 22, standardShare: 100 }] },
@@ -136,9 +158,9 @@ describe("calculateDonationBreakdown", () => {
       4,
     );
 
-    expect(breakdown.causeAreaAmounts).toEqual({ 1: 10, 2: 19, 3: 29 });
-    expect(breakdown.organizationAmounts).toEqual({ 11: 10, 22: 19, 33: 29 });
-    expect(breakdown.operationsAmount).toBe(2);
+    expect(breakdown.causeAreaAmounts).toEqual({ 1: 10, 2: 19, 3: 28 });
+    expect(breakdown.organizationAmounts).toEqual({ 11: 10, 22: 19, 33: 28 });
+    expect(breakdown.operationsAmount).toBe(3);
     expect(breakdown.totalAmount).toBe(60);
     expect(
       Object.values(breakdown.causeAreaAmounts).reduce((sum, amount) => sum + amount, 0) +

--- a/components/shared/components/Widget/utils/donationCalculations.ts
+++ b/components/shared/components/Widget/utils/donationCalculations.ts
@@ -244,44 +244,20 @@ export function calculateDonationBreakdown(
       selectedCauseAreaId !== null &&
       selectedCauseAreaId !== undefined &&
       operationsPercentageModeByCauseArea[selectedCauseAreaId]);
-  const exactCauseAreaAmounts = { ...result.causeAreaAmounts };
-  const roundedCauseAreaAmounts: Record<number, number> = {};
-
-  Object.entries(exactCauseAreaAmounts).forEach(([id, amount]) => {
-    const areaId = Number(id);
-    const area = causeAreas.find((candidate) => candidate.id === areaId);
-    const isCustom = causeAreaDistributionType[areaId] === ShareType.CUSTOM;
-    roundedCauseAreaAmounts[areaId] = isCustom
-      ? (area?.organizations || []).reduce(
-          (sum, org) => sum + Math.round(result.organizationAmounts[org.id] || 0),
-          0,
-        )
-      : Math.round(amount);
-  });
-
-  let roundedDistributedAmount = Object.values(roundedCauseAreaAmounts).reduce(
-    (sum, amount) => sum + amount,
-    0,
+  const targetDistributedAmount = hasOperationsCut
+    ? Math.max(totalAmount - totalOperationsAmount, 0)
+    : totalAmount;
+  const roundedCauseAreaAmounts = roundAmountsToTotal(
+    Object.entries(result.causeAreaAmounts)
+      .map(([id, amount]) => ({ id: Number(id), amount }))
+      .filter(({ amount }) => amount > 0),
+    targetDistributedAmount,
   );
-  const largestCauseAreaId = Object.keys(roundedCauseAreaAmounts)
-    .map(Number)
-    .sort(
-      (left, right) =>
-        roundedCauseAreaAmounts[right] - roundedCauseAreaAmounts[left] || left - right,
-    )[0];
 
-  if (largestCauseAreaId !== undefined) {
-    if (roundedDistributedAmount > totalAmount) {
-      roundedCauseAreaAmounts[largestCauseAreaId] -= roundedDistributedAmount - totalAmount;
-      roundedDistributedAmount = totalAmount;
-    } else if (!hasOperationsCut && roundedDistributedAmount < totalAmount) {
-      roundedCauseAreaAmounts[largestCauseAreaId] += totalAmount - roundedDistributedAmount;
-      roundedDistributedAmount = totalAmount;
-    }
-  }
-
-  result.causeAreaAmounts = roundedCauseAreaAmounts;
-  result.operationsAmount = hasOperationsCut ? totalAmount - roundedDistributedAmount : 0;
+  result.causeAreaAmounts = Object.fromEntries(
+    roundedCauseAreaAmounts.map(({ id, amount }) => [id, amount]),
+  );
+  result.operationsAmount = hasOperationsCut ? totalAmount - targetDistributedAmount : 0;
   result.totalAmount = totalAmount;
 
   causeAreas.forEach((area) => {


### PR DESCRIPTION
Selected distribution in the donation widget:

Cause area 1: 10 kr
Cause area 2: 10 kr
5% til drift: Yes

### Before:

UI shows:
Cause area 1: 11 kr
Cause area 2: 9 kr

Actually submits:
Cause area 1: 10 kr
Cause area 2: 10 kr

### After
UI shows:
Cause area 1: 10 kr
Cause area 2: 9 kr
Drift: 1 kr

Actually submits:
Cause area 1: 10 kr
Cause area 2: 9 kr
Drift: 1 kr
