### PR TITLE
improve labels on donation widget

### DIFF
--- a/components/shared/components/Widget/components/panes/AmountPane/CauseAreaForm.tsx
+++ b/components/shared/components/Widget/components/panes/AmountPane/CauseAreaForm.tsx
@@ -36,6 +36,7 @@ import {
   SmartDistributionContext,
 } from "../../../types/WidgetProps";
 import { InfoAccordion } from "../../shared/InfoAccordion/InfoAccordion";
+import { splitOperationsLabelTemplate } from "../../../utils/operationsLabel";
 
 interface CauseAreaFormProps {
   causeArea: CauseArea;
@@ -86,6 +87,8 @@ export const CauseAreaForm: React.FC<CauseAreaFormProps> = ({
 
   // Get percentage from Redux state
   const currentPercentage = operationsPercentageByCauseArea[causeArea.id] ?? defaultPercentage;
+  const { prefix: operationsLabelPrefix, suffix: operationsLabelSuffix } =
+    splitOperationsLabelTemplate(config?.operations_label_template);
 
   // Check if operations are enabled for this cause area
   const isOperationsEnabled = operationsPercentageModeByCauseArea[causeArea.id] ?? false;
@@ -339,6 +342,7 @@ export const CauseAreaForm: React.FC<CauseAreaFormProps> = ({
               <CustomCheckBox checked={isOperationsEnabled} label="" />
             </CheckBoxWrapper>
             <OperationsPercentageInputWrapper>
+              {operationsLabelPrefix && <span>{operationsLabelPrefix}</span>}
               <span>
                 <NumericFormat
                   name={`percentage-cut-${causeArea.id}`}
@@ -354,9 +358,7 @@ export const CauseAreaForm: React.FC<CauseAreaFormProps> = ({
                   disabled={!isOperationsEnabled}
                 />
               </span>
-              <span>
-                {operationsConfig?.operations_label_template?.replace("{percentage}", "")}
-              </span>
+              {operationsLabelSuffix && <span>{operationsLabelSuffix}</span>}
             </OperationsPercentageInputWrapper>
           </div>
         </div>

--- a/components/shared/components/Widget/components/panes/AmountPane/GlobalCutToggle.tsx
+++ b/components/shared/components/Widget/components/panes/AmountPane/GlobalCutToggle.tsx
@@ -11,6 +11,7 @@ import { CheckBoxWrapper, HiddenCheckBox } from "../Forms.style";
 import { CustomCheckBox } from "../DonorPane/CustomCheckBox";
 import { OperationsPercentageInputWrapper } from "../AmountPane.style";
 import { OperationsConfig } from "../../../types/WidgetProps";
+import { splitOperationsLabelTemplate } from "../../../utils/operationsLabel";
 
 interface GlobalCutToggleProps {
   operationsConfig?: OperationsConfig;
@@ -27,6 +28,8 @@ export const GlobalCutToggle: React.FC<GlobalCutToggleProps> = ({ operationsConf
 
   // Use config from props if available, otherwise from state
   const config = operationsConfig || stateConfig;
+  const { prefix: operationsLabelPrefix, suffix: operationsLabelSuffix } =
+    splitOperationsLabelTemplate(operationsConfig?.operations_label_template);
 
   // Explicitly toggling the global cut applies it to every eligible cause area -
   // otherwise a donor who only meant to turn it off/on globally would still see
@@ -78,6 +81,7 @@ export const GlobalCutToggle: React.FC<GlobalCutToggleProps> = ({ operationsConf
           <CustomCheckBox checked={globalOperationsEnabled} label="" />
         </CheckBoxWrapper>
         <OperationsPercentageInputWrapper>
+          {operationsLabelPrefix && <span>{operationsLabelPrefix}</span>}
           <span>
             <NumericFormat
               name={`global-percentage-cut`}
@@ -95,7 +99,7 @@ export const GlobalCutToggle: React.FC<GlobalCutToggleProps> = ({ operationsConf
               disabled={!globalOperationsEnabled}
             />
           </span>
-          <span>{operationsConfig?.operations_label_template?.replace("{percentage}", "")}</span>
+          {operationsLabelSuffix && <span>{operationsLabelSuffix}</span>}
         </OperationsPercentageInputWrapper>
       </div>
     </div>

--- a/components/shared/components/Widget/utils/operationsLabel.ts
+++ b/components/shared/components/Widget/utils/operationsLabel.ts
@@ -1,0 +1,11 @@
+export const splitOperationsLabelTemplate = (template?: string) => {
+  if (!template) return { prefix: "", suffix: "" };
+
+  const placeholderIndex = template.indexOf("{percentage}");
+  if (placeholderIndex === -1) return { prefix: "", suffix: template.trim() };
+
+  return {
+    prefix: template.slice(0, placeholderIndex).trim(),
+    suffix: template.slice(placeholderIndex + "{percentage}".length).trim(),
+  };
+};

--- a/components/shared/components/Widget/utils/widgetDefaults.ts
+++ b/components/shared/components/Widget/utils/widgetDefaults.ts
@@ -15,7 +15,7 @@ export const DEFAULT_OPERATIONS_CONFIG: Omit<
   // inside a regular cause area) leave it unset.
   operations_cause_area_id: undefined,
   default_percentage: 5,
-  operations_label_template: "{percentage}% to operations",
+  operations_label_template: "of which {percentage}% to operations",
   enabled_by_default_global: false,
   enabled_by_default_single: true,
   excluded_cause_area_ids: [],

--- a/studio/scripts/localizeWidgetTexts.ts
+++ b/studio/scripts/localizeWidgetTexts.ts
@@ -27,7 +27,8 @@ const CONTENT: Record<LocaleKey, Record<string, unknown>> = {
   no: {
     "ui_labels.total_label": "Sum",
     "ui_labels.operations_summary_label": "Drift",
-    "operations_config.operations_label_template": "{percentage} % til drift",
+    "operations_config.operations_label_template": "hvorav {percentage} % til drift",
+    "smart_distribution_context.smart_distribution_label_text": "Om Smart fordeling",
     // Declares which cause area *is* operations, so it never gets tipped on top of
     // itself. Inert until the platform actually has a cause area with this ID.
     "operations_config.operations_cause_area_id": 4,
@@ -41,7 +42,8 @@ const CONTENT: Record<LocaleKey, Record<string, unknown>> = {
   dk: {
     "ui_labels.total_label": "Sum",
     "ui_labels.operations_summary_label": "Drift",
-    "operations_config.operations_label_template": "{percentage} % til drift",
+    "operations_config.operations_label_template": "heraf {percentage} % til drift",
+    "smart_distribution_context.smart_distribution_label_text": "Om Smart fordeling",
     // Declares which cause area *is* operations, so it never gets tipped on top of
     // itself. Inert until the platform actually has a cause area with this ID.
     "operations_config.operations_cause_area_id": 4,
@@ -57,6 +59,8 @@ const CONTENT: Record<LocaleKey, Record<string, unknown>> = {
   sv: {
     "ui_labels.total_label": "Summa",
     "ui_labels.operations_summary_label": "Drift",
+    "operations_config.operations_label_template": "varav {percentage} % till drift",
+    "smart_distribution_context.smart_distribution_label_text": "Om Smart fördelning",
     "operations_config.operations_cause_area_id": 4,
     "cause_area_display_config.cause_area_selection_title":
       "Vilket ändamål vill du göra skillnad för?",


### PR DESCRIPTION
- clarify from the start that "%-til drift" is not going to increase the amount
- clarify the "about" section of "Smart fordeling"