### PR TITLE
make list rows toggleable on mobile

### DIFF
--- a/components/profile/shared/lists/GenericListRow.tsx
+++ b/components/profile/shared/lists/GenericListRow.tsx
@@ -42,6 +42,8 @@ const GenericListRow = <T extends unknown>({ row, expandable }: Props<T>) => {
   const actionRef = useRef<HTMLDivElement>(null);
   useClickOutsideAlerter(actionRef, () => setContextOpen(false));
 
+  const toggleExpanded = () => setExpanded((expanded) => !expanded);
+
   let actions = [];
 
   if (typeof row.contextOptions !== "undefined") {
@@ -76,7 +78,10 @@ const GenericListRow = <T extends unknown>({ row, expandable }: Props<T>) => {
   if (expandable) {
     actions.push(
       <div
-        onClick={() => setExpanded(!expanded)}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          toggleExpanded();
+        }}
         data-cy="generic-list-row-expand"
         className={style.actionContainer}
         key={row.id + "-expand"}
@@ -94,9 +99,7 @@ const GenericListRow = <T extends unknown>({ row, expandable }: Props<T>) => {
     <tbody ref={ref}>
       <tr
         key={row.id}
-        onClick={() => {
-          expandable && window.innerWidth > 1180 ? setExpanded(!expanded) : expanded;
-        }}
+        onClick={() => expandable && toggleExpanded()}
         data-cy="generic-list-row-expand"
         className={expandable ? style.expandableRow : ""}
       >


### PR DESCRIPTION
A bit quality of life improvement for mobile, to be able to tap on the entire list row to expand or collapse it, instead of trying to aim for the little `v` button. The code looks like it was intentional @fellmirr, but I cannot find any reason why it would be so. In my testing everything seems working quite nicely, on agreements page and on tax page. Do let me know if you find a page where this breaks something.