### PR TITLE
donation widget: open org links in new tab on mobile

### DIFF
--- a/components/shared/components/Widget/components/panes/AmountPane/CauseAreaForm.tsx
+++ b/components/shared/components/Widget/components/panes/AmountPane/CauseAreaForm.tsx
@@ -39,6 +39,7 @@ import {
 } from "../../../types/WidgetProps";
 import { CauseAreaRollout } from "../../shared/CauseAreaRollout/CauseAreaRollout";
 import { splitOperationsLabelTemplate } from "../../../utils/operationsLabel";
+import { useIsMobile } from "../../../../../../../hooks/useIsMobile";
 
 interface CauseAreaFormProps {
   causeArea: CauseArea;
@@ -67,6 +68,7 @@ export const CauseAreaForm: React.FC<CauseAreaFormProps> = ({
 }) => {
   const dispatch = useDispatch<any>();
   const plausible = usePlausible();
+  const isMobile = useIsMobile();
   const hasSingleOrg = causeArea.organizations.length <= 1;
   // "Andet"/"Annet" (other) - id 5, per DK_DEMO_CAUSE_AREAS in Widget.tsx and
   // the below-line/excluded-cause-area defaults in widgetDefaults.ts. Donors
@@ -301,7 +303,11 @@ export const CauseAreaForm: React.FC<CauseAreaFormProps> = ({
                     <InputList>
                       {visibleOrganizations.map((org) => (
                         <OrganizationInputWrapper key={org.id}>
-                          <Link href={org.informationUrl || "#"}>
+                          <Link
+                            href={org.informationUrl || "#"}
+                            target={isMobile ? "_blank" : undefined}
+                            rel={isMobile ? "noopener noreferrer" : undefined}
+                          >
                             {org.widgetDisplayName || org.name}
                           </Link>
                           <span>

--- a/components/shared/components/Widget/components/panes/SingleCauseAreaPane/index.tsx
+++ b/components/shared/components/Widget/components/panes/SingleCauseAreaPane/index.tsx
@@ -41,6 +41,7 @@ import { LayoutActionTypes } from "../../../store/layout/types";
 import { thousandize } from "../../../../../../../util/formatting";
 import { useAmountCalculation } from "../AmountPane/useAmountCalculation";
 import { AmountContext, SmartDistributionContext } from "../../../types/WidgetProps";
+import { useIsMobile } from "../../../../../../../hooks/useIsMobile";
 
 interface SingleCauseAreaPaneProps {
   nextButtonText: string;
@@ -73,6 +74,7 @@ export const SingleCauseAreaPane: React.FC<SingleCauseAreaPaneProps> = ({
 }) => {
   const dispatch = useDispatch<Dispatch<DonationActionTypes | LayoutActionTypes>>();
   const plausible = usePlausible();
+  const isMobile = useIsMobile();
 
   const causeAreas = useSelector((state: State) => state.layout.causeAreas);
   const {
@@ -289,7 +291,11 @@ export const SingleCauseAreaPane: React.FC<SingleCauseAreaPaneProps> = ({
                       ).map((org) => (
                         <ShareInputContainer key={org.id}>
                           <div>
-                            <ShareLink href={org.informationUrl}>
+                            <ShareLink
+                              href={org.informationUrl}
+                              target={isMobile ? "_blank" : undefined}
+                              rel={isMobile ? "noopener noreferrer" : undefined}
+                            >
                               {org.widgetDisplayName || org.name}
                             </ShareLink>
                             {org.widgetContext && <ToolTip text={org.widgetContext} />}


### PR DESCRIPTION
On mobile, when donation is full-screen, links to orgs open behind the widget and user doesn't know that they are open. As a solution, on mobile these links will open in a new tab instead.