### PR TITLE
min side: allow configuring impact estimate explanation per cause area

### DIFF
--- a/components/profile/shared/lists/donationList/DonationDetails.tsx
+++ b/components/profile/shared/lists/donationList/DonationDetails.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import style from "./DonationDetails.module.scss";
 import { Distribution, Donation } from "../../../../../models";
 import { Organization } from "../../../../shared/components/Widget/types/Organization";
+import { CauseArea } from "../../../../shared/components/Widget/types/CauseArea";
 import DonationImpact, {
   DonationImpactItemsConfiguration,
 } from "../../../donations/DonationImpact/DonationImpact";
@@ -10,13 +11,43 @@ import AnimateHeight from "react-animate-height";
 import { LinkType, Links } from "../../../../main/blocks/Links/Links";
 import { PortableText } from "@portabletext/react";
 import { NavLink } from "../../../../shared/components/Navbar/Navbar";
+import { groupDonationImpactByCauseArea } from "./impactGroups";
 
-export type DonationDetailsConfiguration = {
-  impact_estimate_header: string;
-  impact_estimate_explanation_title: string;
-  impact_estimate_explanation_text: any[];
-  impact_estimate_explanation_links: (LinkType | NavLink)[];
+type ImpactEstimateExplanationConfiguration = {
+  impact_estimate_explanation_title?: string;
+  impact_estimate_explanation_text?: any[];
+  impact_estimate_explanation_links?: (LinkType | NavLink)[];
+};
+
+type CauseAreaImpactEstimateConfiguration = ImpactEstimateExplanationConfiguration & {
+  cause_area_id: number;
+};
+
+export type DonationDetailsConfiguration = ImpactEstimateExplanationConfiguration & {
+  impact_estimate_header?: string;
+  cause_area_impact_estimates?: CauseAreaImpactEstimateConfiguration[];
   impact_items_configuration: DonationImpactItemsConfiguration;
+};
+
+export const getImpactEstimateConfiguration = (
+  configuration: DonationDetailsConfiguration,
+  causeAreaId: number,
+): ImpactEstimateExplanationConfiguration => {
+  const causeAreaConfiguration = configuration.cause_area_impact_estimates?.find(
+    (candidate) => candidate.cause_area_id === causeAreaId,
+  );
+
+  return {
+    impact_estimate_explanation_title:
+      causeAreaConfiguration?.impact_estimate_explanation_title ??
+      configuration.impact_estimate_explanation_title,
+    impact_estimate_explanation_text:
+      causeAreaConfiguration?.impact_estimate_explanation_text ??
+      configuration.impact_estimate_explanation_text,
+    impact_estimate_explanation_links:
+      causeAreaConfiguration?.impact_estimate_explanation_links ??
+      configuration.impact_estimate_explanation_links,
+  };
 };
 
 export const DonationDetails: React.FC<{
@@ -26,40 +57,91 @@ export const DonationDetails: React.FC<{
   timestamp: Date;
   configuration: DonationDetailsConfiguration;
   organizations: Organization[];
-}> = ({ sum, donation, distribution, timestamp, configuration, organizations }) => {
-  const [showImpactEstimateExplanation, setShowImpactEstimateExplanation] = useState(false);
+  causeAreas: CauseArea[];
+}> = ({ sum, donation, distribution, timestamp, configuration, organizations, causeAreas }) => {
+  const [expandedCauseAreaIds, setExpandedCauseAreaIds] = useState<number[]>([]);
 
   if (!distribution && !donation.impact?.length)
     return <span>Ingen distribusjon funnet for donasjon med KID {donation.KID}</span>;
+
+  const distributionCauseAreas = distribution?.causeAreas ?? [];
+  const impactGroups = groupDonationImpactByCauseArea(
+    donation.impact ?? [],
+    organizations,
+    causeAreas,
+  );
+  const hasPrecomputedImpact = Boolean(donation.impact?.length && impactGroups.length);
+  const visibleCauseAreas = hasPrecomputedImpact
+    ? impactGroups.map((group) => group.causeArea)
+    : distributionCauseAreas;
 
   return (
     <div className={style.wrapper}>
       <div className={style.impactEstimate}>
         <strong>{configuration.impact_estimate_header}</strong>
-        <span
-          className={
-            showImpactEstimateExplanation
-              ? [style.caption, style.captionopen].join(" ")
-              : style.caption
-          }
-          onClick={() => setShowImpactEstimateExplanation(!showImpactEstimateExplanation)}
-        >
-          {configuration.impact_estimate_explanation_title}&nbsp;&nbsp;
-        </span>
-        <AnimateHeight duration={500} height={showImpactEstimateExplanation ? "auto" : 0}>
-          <div className={style.impactExplanationContainer}>
-            <PortableText value={configuration?.impact_estimate_explanation_text} />
-            <Links links={configuration?.impact_estimate_explanation_links}></Links>
-          </div>
-        </AnimateHeight>
+        {visibleCauseAreas.map((causeArea) => {
+          const causeAreaId = causeArea.id;
+          const causeAreaDistribution =
+            distribution && !hasPrecomputedImpact
+              ? {
+                  ...distribution,
+                  causeAreas: distributionCauseAreas.filter(
+                    (distributionCauseArea) => distributionCauseArea.id === causeAreaId,
+                  ),
+                }
+              : distribution;
+          const impactGroup = impactGroups.find((group) => group.causeArea.id === causeAreaId);
+          const causeAreaDonation = hasPrecomputedImpact
+            ? { ...donation, impact: impactGroup?.impact }
+            : donation;
+          const impactEstimateConfiguration = getImpactEstimateConfiguration(
+            configuration,
+            causeAreaId,
+          );
+          const showImpactEstimateExplanation = expandedCauseAreaIds.includes(causeAreaId);
 
-        <DonationImpact
-          donation={donation}
-          distribution={distribution}
-          timestamp={timestamp}
-          configuration={configuration.impact_items_configuration}
-          organizations={organizations}
-        />
+          return (
+            <div key={causeAreaId}>
+              {(impactGroup?.showTitle ?? visibleCauseAreas.length > 1) && (
+                <h5>{causeArea.name}</h5>
+              )}
+              <span
+                className={
+                  showImpactEstimateExplanation
+                    ? [style.caption, style.captionopen].join(" ")
+                    : style.caption
+                }
+                onClick={() =>
+                  setExpandedCauseAreaIds((current) =>
+                    current.includes(causeAreaId)
+                      ? current.filter((id) => id !== causeAreaId)
+                      : [...current, causeAreaId],
+                  )
+                }
+              >
+                {impactEstimateConfiguration.impact_estimate_explanation_title}&nbsp;&nbsp;
+              </span>
+              <AnimateHeight duration={500} height={showImpactEstimateExplanation ? "auto" : 0}>
+                <div className={style.impactExplanationContainer}>
+                  <PortableText
+                    value={impactEstimateConfiguration.impact_estimate_explanation_text}
+                  />
+                  <Links
+                    links={impactEstimateConfiguration.impact_estimate_explanation_links ?? []}
+                  ></Links>
+                </div>
+              </AnimateHeight>
+
+              <DonationImpact
+                donation={causeAreaDonation}
+                distribution={causeAreaDistribution as Distribution}
+                timestamp={timestamp}
+                configuration={configuration.impact_items_configuration}
+                organizations={organizations}
+              />
+            </div>
+          );
+        })}
       </div>
 
       <div className={style.actions}>

--- a/components/profile/shared/lists/donationList/DonationDetails.tsx
+++ b/components/profile/shared/lists/donationList/DonationDetails.tsx
@@ -36,17 +36,18 @@ export const getImpactEstimateConfiguration = (
   const causeAreaConfiguration = configuration.cause_area_impact_estimates?.find(
     (candidate) => candidate.cause_area_id === causeAreaId,
   );
+  const fallbackConfiguration = causeAreaId === 1 ? configuration : undefined;
 
   return {
     impact_estimate_explanation_title:
       causeAreaConfiguration?.impact_estimate_explanation_title ??
-      configuration.impact_estimate_explanation_title,
+      fallbackConfiguration?.impact_estimate_explanation_title,
     impact_estimate_explanation_text:
       causeAreaConfiguration?.impact_estimate_explanation_text ??
-      configuration.impact_estimate_explanation_text,
+      fallbackConfiguration?.impact_estimate_explanation_text,
     impact_estimate_explanation_links:
       causeAreaConfiguration?.impact_estimate_explanation_links ??
-      configuration.impact_estimate_explanation_links,
+      fallbackConfiguration?.impact_estimate_explanation_links,
   };
 };
 
@@ -105,32 +106,36 @@ export const DonationDetails: React.FC<{
               {(impactGroup?.showTitle ?? visibleCauseAreas.length > 1) && (
                 <h5>{causeArea.name}</h5>
               )}
-              <span
-                className={
-                  showImpactEstimateExplanation
-                    ? [style.caption, style.captionopen].join(" ")
-                    : style.caption
-                }
-                onClick={() =>
-                  setExpandedCauseAreaIds((current) =>
-                    current.includes(causeAreaId)
-                      ? current.filter((id) => id !== causeAreaId)
-                      : [...current, causeAreaId],
-                  )
-                }
-              >
-                {impactEstimateConfiguration.impact_estimate_explanation_title}&nbsp;&nbsp;
-              </span>
-              <AnimateHeight duration={500} height={showImpactEstimateExplanation ? "auto" : 0}>
-                <div className={style.impactExplanationContainer}>
-                  <PortableText
-                    value={impactEstimateConfiguration.impact_estimate_explanation_text}
-                  />
-                  <Links
-                    links={impactEstimateConfiguration.impact_estimate_explanation_links ?? []}
-                  ></Links>
-                </div>
-              </AnimateHeight>
+              {impactEstimateConfiguration.impact_estimate_explanation_title && (
+                <>
+                  <span
+                    className={
+                      showImpactEstimateExplanation
+                        ? [style.caption, style.captionopen].join(" ")
+                        : style.caption
+                    }
+                    onClick={() =>
+                      setExpandedCauseAreaIds((current) =>
+                        current.includes(causeAreaId)
+                          ? current.filter((id) => id !== causeAreaId)
+                          : [...current, causeAreaId],
+                      )
+                    }
+                  >
+                    {impactEstimateConfiguration.impact_estimate_explanation_title}&nbsp;&nbsp;
+                  </span>
+                  <AnimateHeight duration={500} height={showImpactEstimateExplanation ? "auto" : 0}>
+                    <div className={style.impactExplanationContainer}>
+                      <PortableText
+                        value={impactEstimateConfiguration.impact_estimate_explanation_text}
+                      />
+                      <Links
+                        links={impactEstimateConfiguration.impact_estimate_explanation_links ?? []}
+                      ></Links>
+                    </div>
+                  </AnimateHeight>
+                </>
+              )}
 
               <DonationImpact
                 donation={causeAreaDonation}

--- a/components/profile/shared/lists/donationList/DonationList.tsx
+++ b/components/profile/shared/lists/donationList/DonationList.tsx
@@ -1,6 +1,7 @@
 import { PortableText } from "@portabletext/react";
 import { Distribution, Donation, TaxUnit } from "../../../../../models";
 import { Organization } from "../../../../shared/components/Widget/types/Organization";
+import { CauseArea } from "../../../../shared/components/Widget/types/CauseArea";
 import { onlyDate, thousandize } from "../../../../../util/formatting";
 import { ErrorMessage } from "../../ErrorMessage/ErrorMessage";
 import { GenericList } from "../GenericList";
@@ -31,6 +32,7 @@ export const DonationList: React.FC<{
   detailsConfiguration?: DonationDetailsConfiguration;
   firstOpen: boolean;
   organizations: Organization[];
+  causeAreas: CauseArea[];
 }> = ({
   donations,
   distributions,
@@ -40,6 +42,7 @@ export const DonationList: React.FC<{
   detailsConfiguration,
   firstOpen,
   organizations,
+  causeAreas,
 }) => {
   let taxDeductionText: ReactNode | undefined = undefined;
 
@@ -111,6 +114,7 @@ export const DonationList: React.FC<{
           timestamp={new Date(donation.timestamp)}
           configuration={detailsConfiguration}
           organizations={organizations}
+          causeAreas={causeAreas}
         />
       ) : (
         <ErrorMessage>Missing donation details configuration in Sanity</ErrorMessage>

--- a/components/profile/shared/lists/donationList/impactGroups.test.ts
+++ b/components/profile/shared/lists/donationList/impactGroups.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@jest/globals";
+import { DonationImpactEntry } from "../../../../../models";
+import { groupDonationImpactByCauseArea } from "./impactGroups";
+
+const causeAreas = [
+  { id: 1, name: "Global sundhed" },
+  { id: 2, name: "Dyrevelfærd" },
+];
+
+const organizations = [
+  { name: "A-vitamin mod fejlernæring", causeAreaId: 1 },
+  { name: "Good Food Institute", causeAreaId: 2 },
+];
+
+const globalHealthImpact: DonationImpactEntry = {
+  unit: "A-vitamintilskud",
+  count: 69.1,
+  amount: 500,
+  recipient: "Forventet: Helen Keller International",
+  organization: "A-vitamin mod fejlernæring",
+};
+
+const animalWelfareImpact: DonationImpactEntry = {
+  unit: "Food units",
+  count: 300,
+  amount: 300,
+  recipient: "Forventet: Good Food Institute",
+  organization: "Good Food Institute",
+};
+
+test("does not show a title for one cause area", () => {
+  const groups = groupDonationImpactByCauseArea([animalWelfareImpact], organizations, [
+    causeAreas[1],
+  ]);
+
+  expect(groups).toEqual([
+    {
+      causeArea: causeAreas[1],
+      impact: [animalWelfareImpact],
+      showTitle: false,
+    },
+  ]);
+});
+
+test("shows titles and groups impact when multiple cause areas are present", () => {
+  const groups = groupDonationImpactByCauseArea(
+    [animalWelfareImpact, globalHealthImpact],
+    organizations,
+    causeAreas,
+  );
+
+  expect(groups).toEqual([
+    {
+      causeArea: causeAreas[0],
+      impact: [globalHealthImpact],
+      showTitle: true,
+    },
+    {
+      causeArea: causeAreas[1],
+      impact: [animalWelfareImpact],
+      showTitle: true,
+    },
+  ]);
+});
+
+test("skips a cause area when the backend sends no impact for it", () => {
+  const groups = groupDonationImpactByCauseArea([animalWelfareImpact], organizations, causeAreas);
+
+  expect(groups.map((group) => group.causeArea.name)).toEqual(["Dyrevelfærd"]);
+  expect(groups[0].showTitle).toBe(false);
+});

--- a/components/profile/shared/lists/donationList/impactGroups.test.ts
+++ b/components/profile/shared/lists/donationList/impactGroups.test.ts
@@ -63,6 +63,27 @@ test("shows titles and groups impact when multiple cause areas are present", () 
   ]);
 });
 
+test("combines impact distributed to the same organization", () => {
+  const secondGlobalHealthImpact: DonationImpactEntry = {
+    ...globalHealthImpact,
+    amount: 100,
+    count: 10,
+  };
+  const groups = groupDonationImpactByCauseArea(
+    [globalHealthImpact, secondGlobalHealthImpact],
+    organizations,
+    causeAreas,
+  );
+
+  expect(groups[0].impact).toEqual([
+    {
+      ...globalHealthImpact,
+      amount: 600,
+      count: 79.1,
+    },
+  ]);
+});
+
 test("skips a cause area when the backend sends no impact for it", () => {
   const groups = groupDonationImpactByCauseArea([animalWelfareImpact], organizations, causeAreas);
 

--- a/components/profile/shared/lists/donationList/impactGroups.ts
+++ b/components/profile/shared/lists/donationList/impactGroups.ts
@@ -1,0 +1,38 @@
+import { DonationImpactEntry } from "../../../../../models";
+import { CauseArea } from "../../../../shared/components/Widget/types/CauseArea";
+import { Organization } from "../../../../shared/components/Widget/types/Organization";
+
+type ImpactCauseArea = Pick<CauseArea, "id" | "name">;
+type ImpactOrganization = Pick<Organization, "name" | "causeAreaId">;
+
+export type DonationImpactGroup = {
+  causeArea: ImpactCauseArea;
+  impact: DonationImpactEntry[];
+  showTitle: boolean;
+};
+
+export const groupDonationImpactByCauseArea = (
+  impact: DonationImpactEntry[],
+  organizations: ImpactOrganization[],
+  causeAreas: ImpactCauseArea[],
+): DonationImpactGroup[] => {
+  const groupedImpact = new Map<number, DonationImpactEntry[]>();
+
+  impact.forEach((entry) => {
+    const causeAreaId = organizations.find(
+      (organization) => organization.name === entry.organization,
+    )?.causeAreaId;
+    if (causeAreaId === undefined) return;
+    groupedImpact.set(causeAreaId, [...(groupedImpact.get(causeAreaId) ?? []), entry]);
+  });
+
+  const groups = causeAreas
+    .filter((causeArea) => groupedImpact.has(causeArea.id))
+    .map((causeArea) => ({
+      causeArea,
+      impact: groupedImpact.get(causeArea.id) ?? [],
+      showTitle: false,
+    }));
+
+  return groups.map((group) => ({ ...group, showTitle: groups.length > 1 }));
+};

--- a/components/profile/shared/lists/donationList/impactGroups.ts
+++ b/components/profile/shared/lists/donationList/impactGroups.ts
@@ -23,7 +23,28 @@ export const groupDonationImpactByCauseArea = (
       (organization) => organization.name === entry.organization,
     )?.causeAreaId;
     if (causeAreaId === undefined) return;
-    groupedImpact.set(causeAreaId, [...(groupedImpact.get(causeAreaId) ?? []), entry]);
+
+    const causeAreaImpact = groupedImpact.get(causeAreaId) ?? [];
+    const existingImpact = causeAreaImpact.find(
+      (candidate) => candidate.organization === entry.organization,
+    );
+
+    if (existingImpact) {
+      groupedImpact.set(
+        causeAreaId,
+        causeAreaImpact.map((candidate) =>
+          candidate === existingImpact
+            ? {
+                ...candidate,
+                amount: candidate.amount + entry.amount,
+                count: candidate.count + entry.count,
+              }
+            : candidate,
+        ),
+      );
+    } else {
+      groupedImpact.set(causeAreaId, [...causeAreaImpact, entry]);
+    }
   });
 
   const groups = causeAreas

--- a/pages/dashboard/DonationsPage.tsx
+++ b/pages/dashboard/DonationsPage.tsx
@@ -11,6 +11,7 @@ import { DonorContext } from "../../components/profile/layout/donorProvider";
 import {
   useAggregatedDonations,
   useAllOrganizations,
+  useCauseAreas,
   useDistributions,
   useDonations,
   useTaxUnits,
@@ -215,6 +216,8 @@ export const DonationsPage = withStaticProps(
     error: organizationsError,
   } = useAllOrganizations(getAccessTokenSilently);
 
+  const { data: causeAreas, loading: causeAreasLoading } = useCauseAreas(getAccessTokenSilently);
+
   const {
     data: taxUnits,
     loading: taxUnitsLoading,
@@ -224,6 +227,7 @@ export const DonationsPage = withStaticProps(
   const donationsLoaded = Array.isArray(donations);
   const aggregatedDonationsLoaded = Array.isArray(aggregatedDonations);
   const organizationsLoaded = Array.isArray(organizations);
+  const causeAreasLoaded = Array.isArray(causeAreas);
   const taxUnitsLoaded = Array.isArray(taxUnits);
   const resolvedDistributions = shouldFetchDistributions ? distributions : [];
   const distributionsLoaded = Array.isArray(resolvedDistributions);
@@ -239,6 +243,7 @@ export const DonationsPage = withStaticProps(
     aggregatedDonationsLoaded &&
     donor &&
     organizationsLoaded &&
+    causeAreasLoaded &&
     taxUnitsLoaded &&
     distributionsLoaded;
   const loading =
@@ -246,6 +251,7 @@ export const DonationsPage = withStaticProps(
     donationsLoading ||
     (shouldFetchDistributions && distributionsLoading) ||
     organizationsloading ||
+    causeAreasLoading ||
     taxUnitsLoading;
 
   if (!dataAvailable || loading)
@@ -295,6 +301,7 @@ export const DonationsPage = withStaticProps(
         detailsConfiguration={page.donations_details_configuration}
         firstOpen={false}
         organizations={organizations}
+        causeAreas={causeAreas}
       />
     ) : (
       <ErrorMessage>
@@ -393,6 +400,7 @@ export const DonationsPage = withStaticProps(
             detailsConfiguration={page.donations_details_configuration}
             firstOpen={false}
             organizations={organizations}
+            causeAreas={causeAreas}
           />
         ) : (
           <ErrorMessage key={year}>
@@ -422,6 +430,7 @@ export const DonationsPage = withStaticProps(
         detailsConfiguration={page.donations_details_configuration}
         firstOpen={false}
         organizations={organizations}
+        causeAreas={causeAreas}
       />
     );
   }
@@ -548,6 +557,9 @@ const fetchDonationsPage = groq`
     mobile_donations_table_configuration,
     donations_details_configuration {
       ...,
+      cause_area_impact_estimates[] {
+        ...,
+      },
       impact_items_configuration {
         ...,
         "currency": *[ _type == "site_settings"][0].main_currency,

--- a/studio/schemas/types/donationstabledetailsconfiguration.ts
+++ b/studio/schemas/types/donationstabledetailsconfiguration.ts
@@ -1,4 +1,5 @@
 import { defineType, defineField } from "sanity";
+import { CauseAreaSelectInput } from "../../components/causeAreaSelectInput";
 
 export default defineType({
   name: "donationstabledetailsconfiguration",
@@ -12,20 +13,70 @@ export default defineType({
     }),
     defineField({
       name: "impact_estimate_explanation_title",
-      title: "Impact estimate explanation title",
+      title: "OBSOLETE - Impact estimate explanation title",
       type: "string",
     }),
     defineField({
       name: "impact_estimate_explanation_text",
-      title: "Impact estimate explanation text",
+      title: "OBSOLETE - Impact estimate explanation text",
       type: "array",
       of: [{ type: "block" }],
     }),
     defineField({
       name: "impact_estimate_explanation_links",
-      title: "Impact estimate explanation links",
+      title: "OBSOLETE - Impact estimate explanation links",
       type: "array",
       of: [{ type: "link" }, { type: "navitem" }],
+    }),
+    defineField({
+      name: "cause_area_impact_estimates",
+      title: "Cause-specific impact estimates",
+      type: "array",
+      of: [
+        {
+          type: "object",
+          name: "cause_area_impact_estimate",
+          fields: [
+            defineField({
+              name: "cause_area_id",
+              title: "Cause area",
+              type: "number",
+              components: { input: CauseAreaSelectInput },
+              validation: (rule) => rule.required(),
+            }),
+            defineField({
+              name: "impact_estimate_explanation_title",
+              title: "Impact estimate explanation title",
+              type: "string",
+            }),
+            defineField({
+              name: "impact_estimate_explanation_text",
+              title: "Impact estimate explanation text",
+              type: "array",
+              of: [{ type: "block" }],
+            }),
+            defineField({
+              name: "impact_estimate_explanation_links",
+              title: "Impact estimate explanation links",
+              type: "array",
+              of: [{ type: "link" }, { type: "navitem" }],
+            }),
+          ],
+          preview: {
+            select: { causeAreaId: "cause_area_id" },
+            prepare: ({ causeAreaId }) => ({ title: `Cause area ID ${causeAreaId}` }),
+          },
+        },
+      ],
+      validation: (rule) =>
+        rule.custom((items: Array<{ cause_area_id?: number }> | undefined) => {
+          const causeAreaIds = (items ?? [])
+            .map((item) => item.cause_area_id)
+            .filter((id): id is number => id !== undefined);
+          return new Set(causeAreaIds).size === causeAreaIds.length
+            ? true
+            : "Only one impact estimate can be configured per cause area";
+        }),
     }),
     defineField({
       name: "impact_items_configuration",


### PR DESCRIPTION
The goal is to allow configuring in Sanity different texts for impact estimate explanation for different cause areas, without changing the UI when only one cause area is present.



https://github.com/user-attachments/assets/89c7b961-ff6f-4fc5-aaab-7f6500cf7e2f



