### PR TITLE
Fix row gap in Smart fordeling point list

### DIFF
--- a/components/main/blocks/PointList/PointList.module.scss
+++ b/components/main/blocks/PointList/PointList.module.scss
@@ -5,6 +5,7 @@
   grid-auto-flow: column;
   grid-auto-columns: minmax(0, 1fr);
   column-gap: 40px;
+  row-gap: 2rem;
   width: 100%;
   margin-top: 80px;
   margin-bottom: 110px;


### PR DESCRIPTION
## Summary
- Add row-gap to the PointList grid so wrapped rows don't sit flush against each other.

## Test plan
- [ ] Visually verify point list spacing in Smart fordeling on a narrow viewport where rows wrap